### PR TITLE
Fix the PGXN version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It has integrations into both OpenAI's embedding's endpoint and a self-hosted co
 One function call to initialize your data. Another function call to search.
 
 [![Static Badge](https://img.shields.io/badge/%40tembo-community?logo=slack&label=slack)](https://join.slack.com/t/tembocommunity/shared_invite/zt-20dtnhcmo-pLNV7_Aobi50TdTLpfQ~EQ)
-[![PGXN version](https://badge.fury.io/pg/pg_vectorize.svg)](https://pgxn.org/dist/pg_vectorize/)
+[![PGXN version](https://badge.fury.io/pg/vectorize.svg)](https://pgxn.org/dist/vectorize/)
 
 - [pg\_vectorize](#pg_vectorize)
   - [Installation](#installation)


### PR DESCRIPTION
The distribution is called `vectorize`, not `pg_vectorize`.