### PR TITLE
upgrade test

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -128,8 +128,6 @@ jobs:
         run: |
           pgrx15_config=$(/usr/local/bin/stoml ~/.pgrx/config.toml configs.pg15)
           pg_version=$(/usr/local/bin/stoml Cargo.toml features.default)
-          git fetch --tags
-          git checkout tags/v0.9.0
           echo "\q" | make run
           make test-integration
 

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run old version (v0.9.0)
         # make commands not present on 0.9 release
         run: |
-          echo "\q" | $(MAKE) run
+          echo "\q" | make run
           cargo test -- --ignored --test-threads=1
       - name: Checkout branch's version
         env:

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -45,10 +45,9 @@ jobs:
         with:
           working-directory: ./
           force: true
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
-      - name: Install extension dependencies
+      - name: Install sys dependencies
         run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           make install-dependencies
       - name: Run old version (v0.9.0)
         run: |

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -51,11 +51,11 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           make setup
-      - name: Checkout old version (v0.9.0)
+      - name: Checkout old version (v0.10.0)
         run: |
           git fetch --tags
-          git checkout tags/v0.9.0
-      - name: Run old version (v0.9.0)
+          git checkout tags/v0.10.0
+      - name: Run old version (v0.10.0)
         # make commands not present on 0.9 release
         run: |
           echo "\q" | make run

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           make setup
-      - name: Test previous version (v0.10.0)
+      - name: Test previous version (main))
         run: |
           git fetch --tags
           git checkout main

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -51,8 +51,10 @@ jobs:
           git fetch --tags
           git checkout tags/v0.9.0
       - name: Run old version (v0.9.0)
+        # make commands not present on 0.9 release
         run: |
-          make test-version
+          echo "\q" | $(MAKE) run
+          cargo test -- --ignored --test-threads=1
       - name: Checkout branch's version
         env:
           CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -69,10 +69,6 @@ jobs:
       - uses: ./.github/actions/pgx-init
         with:
           working-directory: ./
-          force: true
-      - name: Upgrade and run tests
-        run: |
-          make test-upgrade
       - name: Debugging information
         if: always()
         run: |

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -20,6 +20,11 @@ jobs:
   test:
     name: Upgrade Test
     runs-on: ubuntu-22.04
+    services:
+      vector-serve:
+        image: quay.io/tembo/vector-serve:latest
+        ports:
+          - 3000:3000
     steps:
       - name: Checkout repository content
         uses: actions/checkout@v2

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -64,6 +64,7 @@ jobs:
         env:
           CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}
         run: |
+          git checkout $CI_BRANCH
           test-branch BRANCH=$CI_BRANCH
       - uses: ./.github/actions/pgx-init
         with:

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -39,20 +39,17 @@ jobs:
       - name: Get current version
         id: current-version
         run: echo "CI_BRANCH=$(git name-rev --name-only HEAD)" >> $GITHUB_OUTPUT
+      - uses: ./.github/actions/pgx-init
+        with:
+          working-directory: ./
+      - name: Install sys dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
+          make setup
       - name: Checkout old version (v0.9.0)
         run: |
           git fetch --tags
           git checkout tags/v0.9.0
-      - uses: ./.github/actions/pgx-init
-        with:
-          working-directory: ./
-          force: true
-      - name: Install sys dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
-          ls -alh
-          cat Makefile
-          make setup
       - name: Run old version (v0.9.0)
         run: |
           make test-version

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install sys dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
-          make install-dependencies
+          make setup
       - name: Run old version (v0.9.0)
         run: |
           rm -rf ./target/pgrx-test-data-* || true

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -51,24 +51,18 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           make setup
-      - name: Checkout old version (v0.10.0)
+      - name: Test previous version (v0.10.0)
         run: |
           git fetch --tags
           git checkout tags/v0.10.0
-      - name: Run old version (v0.10.0)
-        # make commands not present on 0.9 release
-        run: |
           echo "\q" | make run
           cargo test -- --ignored --test-threads=1
-      - name: Checkout branch's version
+      - name: Test branch's version
         env:
           CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}
         run: |
           git checkout $CI_BRANCH
-          make test-branch BRANCH=$CI_BRANCH
-      - uses: ./.github/actions/pgx-init
-        with:
-          working-directory: ./
+          make test-update
       - name: Debugging information
         if: always()
         run: |

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -47,7 +47,7 @@ jobs:
           force: true
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
-      - name: Install pg_partman
+      - name: Install extension dependencies
         run: |
           make install-dependencies
       - name: Run old version (v0.9.0)

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -65,7 +65,7 @@ jobs:
           CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}
         run: |
           git checkout $CI_BRANCH
-          test-branch BRANCH=$CI_BRANCH
+          make test-branch BRANCH=$CI_BRANCH
       - uses: ./.github/actions/pgx-init
         with:
           working-directory: ./

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -49,10 +49,10 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           ls -alh
+          cat Makefile
           make setup
       - name: Run old version (v0.9.0)
         run: |
-          rm -rf ./target/pgrx-test-data-* || true
           make test-version
       - name: Checkout branch's version
         env:

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -21,7 +21,9 @@ jobs:
     name: Upgrade Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository content
+        uses: actions/checkout@v2
+
       - name: Install Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Install sys dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
+          ls -alh
           make setup
       - name: Run old version (v0.9.0)
         run: |

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -1,0 +1,68 @@
+name: Extension Upgrade
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
+
+jobs:
+  test:
+    name: Upgrade Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "extension-upgrade-test"
+          workspaces: |
+            vectorize
+          # Additional directories to cache
+          cache-directories: |
+            /home/runner/.pgrx
+      - name: Get current version
+        id: current-version
+        run: echo "CI_BRANCH=$(git name-rev --name-only HEAD)" >> $GITHUB_OUTPUT
+      - name: Checkout old version (v0.9.0)
+        run: |
+          git fetch --tags
+          git checkout tags/v0.9.0
+      - uses: ./.github/actions/pgx-init
+        with:
+          working-directory: ./
+          force: true
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
+      - name: Install pg_partman
+        run: |
+          make install-dependencies
+      - name: Run old version (v0.9.0)
+        run: |
+          rm -rf ./target/pgrx-test-data-* || true
+          make test-version
+      - name: Checkout branch's version
+        env:
+          CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}
+        run: |
+          test-branch BRANCH=$CI_BRANCH
+      - uses: ./.github/actions/pgx-init
+        with:
+          working-directory: ./
+          force: true
+      - name: Upgrade and run tests
+        run: |
+          make test-upgrade

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -73,3 +73,7 @@ jobs:
       - name: Upgrade and run tests
         run: |
           make test-upgrade
+      - name: Debugging information
+        if: always()
+        run: |
+          make cat-logs

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,14 @@ clean:
 install_pg_cron:
 	git clone https://github.com/citusdata/pg_cron.git && \
 	cd pg_cron && \
+	PG_CONFIG=${PGRX_PG_CONFIG} make clean && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make install
 
 install_pg_vector:
 	git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git && \
 	cd pgvector && \
+	PG_CONFIG=${PGRX_PG_CONFIG} make clean && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make install
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip
 
 install-dependencies: install-pg_cron install-pg_vector install-pgmq
+	echo "shared_preload_libraries = 'pg_cron, vectorize'" >> ~/.pgrx/data-${PG_VERSION}/postgresql.conf
 
 install-pg_cron:
 	git clone https://github.com/citusdata/pg_cron.git && \
@@ -61,13 +62,13 @@ RUN_VER:=0.9.0
 test-version:
 	git fetch --tags
 	git checkout tags/v${RUN_VER}
-	echo "\q" | make run
+	echo "\q" | $(MAKE) run
 	cargo test -- --ignored --test-threads=1
 
 BRANCH:=main
 test-branch:
 	git checkout ${BRANCH}
-	echo "\q" | make run
+	echo "\q" | $(MAKE) run
 	$(MAKE) test-integration
 
 test-upgrade:

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,13 @@ test-integration:
 test-unit:
 	cargo pgrx test
 
-
 # tests upgrading from specific version
 RUN_VER:=0.9.0
 test-version:
 	git fetch --tags
 	git checkout tags/v${RUN_VER}
 	echo "\q" | make run
-	$(MAKE) test-integration
+	cargo test -- --ignored --test-threads=1
 
 BRANCH:=main
 test-branch:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-unit:
 
 
 # tests upgrading from specific version
-RUN_VER:=0.8.0
+RUN_VER:=0.9.0
 test-version:
 	git fetch --tags
 	git checkout tags/v${RUN_VER}

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,5 @@ test-version:
 test-branch:
 	git checkout ${BRANCH}
 	echo "\q" | make run
-	make test-integration
-
-test-upgrade:
-	make test-version RUN_VER=${RUN_VER}
 	psql -c "ALTER EXTENSION vectorize UPDATE"
-	make test-branch BRANCH=${BRANCH}
+	make test-integration

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DISTVERSION  = $(shell grep -m 1 '^version' Trunk.toml | sed -e 's/[^"]*"\([^"]*
 PG_VERSION:=15
 PGRX_PG_CONFIG =$(shell cargo pgrx info pg-config pg${PG_VERSION})
 UPGRADE_FROM_VER:=0.9.0
+BRANCH:=$(git rev-parse --abbrev-ref HEAD)
 
 .PHONY: install-pg_cron install-pg_vector install-pgmq run setup test-integration test-unit test-version test-branch test-upgrade
 
@@ -67,16 +68,15 @@ test-unit:
 test-version:
 	git fetch --tags
 	git checkout tags/v${UPGRADE_FROM_VER}
-	echo "\q" | $(MAKE) run
+	echo "\q" | make run
 	cargo test -- --ignored --test-threads=1
 
-BRANCH:=main
 test-branch:
 	git checkout ${BRANCH}
-	echo "\q" | $(MAKE) run
-	$(MAKE) test-integration
+	echo "\q" | make run
+	make test-integration
 
 test-upgrade:
-	$(MAKE) test-version RUN_VER=${RUN_VER}
+	make test-version RUN_VER=${RUN_VER}
 	psql -c "ALTER EXTENSION vectorize UPDATE"
-	$(MAKE) test-branch BRANCH=${BRANCH}
+	make test-branch BRANCH=${BRANCH}

--- a/Makefile
+++ b/Makefile
@@ -38,21 +38,25 @@ setup: install-pg_cron install-pg_vector install-pgmq
 install-pg_cron:
 	git clone https://github.com/citusdata/pg_cron.git && \
 	cd pg_cron && \
+	sed -i.bak 's/-Werror//g' Makefile && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make clean && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make && \
-	PG_CONFIG=${PGRX_PG_CONFIG} make install
+	PG_CONFIG=${PGRX_PG_CONFIG} make install && \
+	cd .. && rm -rf pg_cron
 
 install-pgvector:
 	git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git && \
 	cd pgvector && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make clean && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make && \
-	PG_CONFIG=${PGRX_PG_CONFIG} make install
+	PG_CONFIG=${PGRX_PG_CONFIG} make install && \
+	cd .. && rm -rf pgvector
 
 install-pgmq:
 	git clone https://github.com/tembo-io/pgmq.git && \
 	cd pgmq && \
-	cargo pgrx install --pg-config=${PGRX_PG_CONFIG}
+	cargo pgrx install --pg-config=${PGRX_PG_CONFIG} && \
+	cd .. && rm -rf pgmq
 
 test-integration:
 	cargo test -- --ignored --test-threads=1

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DISTNAME = $(shell grep -m 1 '^name' Trunk.toml | sed -e 's/[^"]*"\([^"]*\)",\{0
 DISTVERSION  = $(shell grep -m 1 '^version' Trunk.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
 PG_VERSION:=15
 PGRX_PG_CONFIG =$(shell cargo pgrx info pg-config pg${PG_VERSION})
+UPGRADE_FROM_VER:=0.9.0
 
 sqlx-cache:
 	cargo sqlx prepare
@@ -57,11 +58,9 @@ test-integration:
 test-unit:
 	cargo pgrx test
 
-# tests upgrading from specific version
-RUN_VER:=0.9.0
 test-version:
 	git fetch --tags
-	git checkout tags/v${RUN_VER}
+	git checkout tags/v${UPGRADE_FROM_VER}
 	echo "\q" | $(MAKE) run
 	cargo test -- --ignored --test-threads=1
 

--- a/Makefile
+++ b/Makefile
@@ -29,21 +29,23 @@ pgxn-zip: $(DISTNAME)-$(DISTVERSION).zip
 clean:
 	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip
 
-install_pg_cron:
+install-dependencies: install-pg_cron install-pg_vector install-pgmq
+
+install-pg_cron:
 	git clone https://github.com/citusdata/pg_cron.git && \
 	cd pg_cron && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make clean && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make install
 
-install_pg_vector:
+install-pgvector:
 	git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git && \
 	cd pgvector && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make clean && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make && \
 	PG_CONFIG=${PGRX_PG_CONFIG} make install
 
-install_pgmq:
+install-pgmq:
 	git clone https://github.com/tembo-io/pgmq.git && \
 	cd pgmq && \
 	cargo pgrx install --pg-config=${PGRX_PG_CONFIG}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PG_VERSION:=15
 PGRX_PG_CONFIG =$(shell cargo pgrx info pg-config pg${PG_VERSION})
 UPGRADE_FROM_VER:=0.9.0
 
+.PHONY: install-pg_cron install-pg_vector install-pgmq run setup test-integration test-unit test-version test-branch test-upgrade
+
 sqlx-cache:
 	cargo sqlx prepare
 

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ test-version:
 	git fetch --tags
 	git checkout tags/v${UPGRADE_FROM_VER}
 	echo "\q" | make run
+	psql ${DATABASE_URL} -c "DROP EXTENSION IF EXISTS vectorize"
 	cargo test -- --ignored --test-threads=1
 
 test-update:

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ install-pgmq:
 	cd .. && rm -rf pgmq
 
 test-integration:
+	echo "\q" | make run
 	cargo test -- --ignored --test-threads=1
 
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ clean:
 setup: install-pg_cron install-pgvector install-pgmq
 	echo "shared_preload_libraries = 'pg_cron, vectorize'" >> ~/.pgrx/data-${PG_VERSION}/postgresql.conf
 
+cat-logs:
+	cat ~/.pgrx/${PG_VERSION}.log
+
 install-pg_cron:
 	git clone https://github.com/citusdata/pg_cron.git && \
 	cd pg_cron && \

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ pgxn-zip: $(DISTNAME)-$(DISTVERSION).zip
 clean:
 	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip
 
-install-dependencies: install-pg_cron install-pg_vector install-pgmq
+setup: install-pg_cron install-pg_vector install-pgmq
 	echo "shared_preload_libraries = 'pg_cron, vectorize'" >> ~/.pgrx/data-${PG_VERSION}/postgresql.conf
 
 install-pg_cron:

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ test-version:
 	echo "\q" | make run
 	cargo test -- --ignored --test-threads=1
 
-test-branch:
-	git checkout ${BRANCH}
+test-update:
 	echo "\q" | make run
 	psql -c "ALTER EXTENSION vectorize UPDATE"
 	make test-integration

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ pgxn-zip: $(DISTNAME)-$(DISTVERSION).zip
 clean:
 	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip
 
-setup: install-pg_cron install-pg_vector install-pgmq
+setup: install-pg_cron install-pgvector install-pgmq
 	echo "shared_preload_libraries = 'pg_cron, vectorize'" >> ~/.pgrx/data-${PG_VERSION}/postgresql.conf
 
 install-pg_cron:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SQLX_OFFLINE:=true
 DATABASE_URL:=postgres://${USER}:${USER}@localhost:28815/postgres
 DISTNAME = $(shell grep -m 1 '^name' Trunk.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
 DISTVERSION  = $(shell grep -m 1 '^version' Trunk.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+PG_VERSION:=15
+PGRX_PG_CONFIG =$(shell cargo pgrx info pg-config pg${PG_VERSION})
 
 sqlx-cache:
 	cargo sqlx prepare
@@ -12,7 +14,7 @@ format:
 
 # ensure the DATABASE_URL is not used, since pgrx will stop postgres during compile
 run:
-	SQLX_OFFLINE=true DATABASE_URL=${DATABASE_URL} cargo pgrx run pg15 postgres
+	SQLX_OFFLINE=true DATABASE_URL=${DATABASE_URL} cargo pgrx run pg${PG_VERSION} postgres
 
 META.json: META.json.in Trunk.toml
 	@sed "s/@CARGO_VERSION@/$(DISTVERSION)/g" META.json.in > META.json
@@ -27,9 +29,45 @@ pgxn-zip: $(DISTNAME)-$(DISTVERSION).zip
 clean:
 	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip
 
+install_pg_cron:
+	git clone https://github.com/citusdata/pg_cron.git && \
+	cd pg_cron && \
+	PG_CONFIG=${PGRX_PG_CONFIG} make && \
+	PG_CONFIG=${PGRX_PG_CONFIG} make install
+
+install_pg_vector:
+	git clone --branch v0.6.0 https://github.com/pgvector/pgvector.git && \
+	cd pgvector && \
+	PG_CONFIG=${PGRX_PG_CONFIG} make && \
+	PG_CONFIG=${PGRX_PG_CONFIG} make install
+
+install_pgmq:
+	git clone https://github.com/tembo-io/pgmq.git && \
+	cd pgmq && \
+	cargo pgrx install --pg-config=${PGRX_PG_CONFIG}
 
 test-integration:
 	cargo test -- --ignored --test-threads=1
 
 test-unit:
 	cargo pgrx test
+
+
+# tests upgrading from specific version
+RUN_VER:=0.8.0
+test-version:
+	git fetch --tags
+	git checkout tags/v${RUN_VER}
+	echo "\q" | make run
+	$(MAKE) test-integration
+
+BRANCH:=main
+test-branch:
+	git checkout ${BRANCH}
+	echo "\q" | make run
+	$(MAKE) test-integration
+
+test-upgrade:
+	$(MAKE) test-version RUN_VER=${RUN_VER}
+	psql -c "ALTER EXTENSION vectorize UPDATE"
+	$(MAKE) test-branch BRANCH=${BRANCH}

--- a/src/util.rs
+++ b/src/util.rs
@@ -169,3 +169,21 @@ pub fn get_pg_options(cfg: Config) -> Result<PgConnectOptions> {
         }
     }
 }
+
+pub async fn ready(conn: &Pool<Postgres>) -> bool {
+    sqlx::query_scalar(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM pg_tables
+            WHERE schemaname = 'vectorize'
+        ) AND EXISTS (
+            SELECT 1
+            FROM pg_tables
+            WHERE schemaname = 'pgmq'
+            AND tablename = 'q_vectorize_jobs'
+        ) AS both_exist;",
+    )
+    .fetch_one(conn)
+    .await
+    .expect("failed")
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -87,22 +87,10 @@ async fn test_realtime_job() {
     .await
     .expect("failed to init job");
 
-    // embedding should be updated after few seconds
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    let result = sqlx::query(&format!(
-        "SELECT vectorize.search(
-        job_name => '{job_name}',
-        query => 'mobile devices',
-        return_columns => ARRAY['product_name', 'product_id'],
-        num_results => 3
-    );"
-    ))
-    .execute(&conn)
-    .await
-    .expect("failed to select from test_table");
-    // 3 rows returned
-    assert_eq!(result.rows_affected(), 3);
+    let search_results = common::search_with_retry(&conn, "mobile devices", &job_name, 10, 2)
+        .await
+        .expect("failed to exec search");
+    assert_eq!(search_results.len(), 3);
 
     let random_product_id = rng.gen_range(0..100000);
 
@@ -117,42 +105,20 @@ async fn test_realtime_job() {
         .await
         .expect("failed to insert into test_table");
 
-    // embedding should be updated after few seconds
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    #[allow(dead_code)]
-    #[derive(FromRow, Debug, serde::Deserialize)]
-    struct SearchResult {
-        product_id: i32,
-        product_name: String,
-        similarity_score: f64,
-    }
-
-    #[allow(dead_code)]
-    #[derive(FromRow, Debug)]
-    struct SearchJSON {
-        search_results: serde_json::Value,
-    }
-
-    let result = sqlx::query_as::<_, SearchJSON>(&format!(
-        "SELECT search_results from vectorize.search(
-        job_name => '{job_name}',
-        query => 'car testing devices',
-        return_columns => ARRAY['product_id','product_name'],
-        num_results => 3
-    ) as search_results;"
-    ))
-    .fetch_all(&conn)
-    .await
-    .expect("failed to execute search");
+    // index will need to rebuild
+    tokio::time::sleep(tokio::time::Duration::from_secs(5 as u64)).await;
+    let search_results = common::search_with_retry(&conn, "car testing devices", &job_name, 10, 2)
+        .await
+        .expect("failed to exec search");
 
     let mut found_it = false;
-    for row in result {
-        println!("row: {:?}", row);
-        let row: SearchResult = serde_json::from_value(row.search_results).unwrap();
+    for row in search_results {
+        let row: common::SearchResult = serde_json::from_value(row.search_results).unwrap();
         if row.product_id == random_product_id {
             assert_eq!(row.product_name, "car tester");
             found_it = true;
+        } else {
+            println!("row: {:?}", row);
         }
     }
     assert!(found_it);
@@ -184,20 +150,9 @@ async fn test_rag() {
     .await
     .expect("failed to init job");
 
-    // embedding should be updated after few seconds
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
     // must be able to conduct vector search on agent tables
-    let result = sqlx::query(&format!(
-        "SELECT vectorize.search(
-        job_name => '{agent_name}',
-        query => 'car testing devices',
-        return_columns => ARRAY['description'],
-        num_results => 3
-    );"
-    ))
-    .execute(&conn)
-    .await
-    .expect("failed to select from test_table");
-    assert_eq!(result.rows_affected(), 3);
+    let search_results = common::search_with_retry(&conn, "mobile devices", &agent_name, 10, 2)
+        .await
+        .expect("failed to exec search");
+    assert_eq!(search_results.len(), 3);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,7 +1,5 @@
-use rand::Rng;
 mod util;
-use sqlx::FromRow;
-
+use rand::Rng;
 use util::common;
 
 // Integration tests are ignored by default


### PR DESCRIPTION
- add a CI workflow to test current against an existing deployment from `main`. This will change from `main` to 0.10.1 or whatever the next release is after that happens.
- updates integrations tests to handle retries better