### PR TITLE
inherit constraints on examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,7 @@ Running the earlier SHOW command should reveal the appropriate change:
 ```sql
 SHOW vectorize.embedding_service_url;
 ```
+
 ```text
    vectorize.embedding_service_url
 -------------------------------------
@@ -175,7 +176,7 @@ Begin by creating a `producs` table with the dataset that comes included with `p
 
 ```sql
 CREATE TABLE products AS
-SELECT * FROM vectorize.example_products;
+TABLE vectorize.example_products WITH DATA;
 ```
 
 You can then confirm everything is correct by running the following:
@@ -183,6 +184,7 @@ You can then confirm everything is correct by running the following:
 ```sql
 SELECT * FROM products limit 2;
 ```
+
 ```text
  product_id | product_name |                      description                       |        last_updated_at        
 ------------+--------------+--------------------------------------------------------+-------------------------------
@@ -201,6 +203,7 @@ columns => ARRAY['product_name', 'description'],
 transformer => 'sentence-transformers/multi-qa-MiniLM-L6-dot-v1'
 );
 ```
+
 ```text
                     table
 ---------------------------------------------

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Setup a products table. Copy from the example data provided by the extension.
 
 ```sql
 CREATE TABLE products AS 
-SELECT * FROM vectorize.example_products;
+TABLE vectorize.example_products WITH DATA;
 ```
 
 ```sql
@@ -167,7 +167,7 @@ Create an example table if it does not already exist.
 
 ```sql
 CREATE TABLE products AS 
-SELECT * FROM vectorize.example_products;
+TABLE vectorize.example_products WITH DATA;
 ```
 
 Initialize a table for RAG. We'll use an open source Sentence Transformer to generate embeddings.

--- a/docs/examples/openai_embeddings.md
+++ b/docs/examples/openai_embeddings.md
@@ -14,7 +14,7 @@ Create an example table if it does not already exist.
 
 ```sql
 CREATE TABLE products AS 
-SELECT * FROM vectorize.example_products;
+TABLE vectorize.example_products WITH DATA;
 ```
 
 Then create the job.

--- a/docs/examples/sentence_transformers.md
+++ b/docs/examples/sentence_transformers.md
@@ -35,7 +35,7 @@ Create an example table if it does not already exist.
 
 ```sql
 CREATE TABLE products AS 
-SELECT * FROM vectorize.example_products;
+TABLE vectorize.example_products WITH DATA;
 ```
 
 ```sql

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -193,7 +193,7 @@ async fn test_static() {
     let test_table_name = "products_test_static";
     let job_name = "static_test_job";
     let query = format!(
-        "CREATE TABLE IF NOT EXISTS {test_table_name} as SELECT * from vectorize.example_products;"
+        "CREATE TABLE IF NOT EXISTS {test_table_name} AS TABLE vectorize.example_products WITH DATA;"
     );
     let _ = sqlx::query(&query)
         .execute(&conn)

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -86,7 +86,7 @@ pub mod common {
 
     pub async fn init_test_table(test_num: i32, conn: &Pool<Postgres>) -> String {
         let table = format!("product_{test_num}");
-        let q = format!("CREATE TABLE {table} as SELECT * from vectorize.example_products;");
+        let q = format!("CREATE TABLE {table} AS TABLE vectorize.example_products WITH DATA");
         let _ = sqlx::query(&q)
             .execute(conn)
             .await


### PR DESCRIPTION
copies table constraints on all the examples, which meant product_id column was missing unique constraint in all the examples, which was causing some problems with tests.