### PR TITLE
Update error handling for vectorize.init_rag() when table not present

### DIFF
--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -215,7 +215,7 @@ pub fn get_column_datatype(schema: &str, table: &str, column: &str) -> Result<St
     })?
     .ok_or_else(|| {
         anyhow!(
-            "Table `{}.{}` is empty, does not exist, or column `{}` does not exist.",
+            "An unknown error occurred while fetching the data type for column `{}` in `{}.{}`.",
             schema,
             table,
             column

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use pgrx::prelude::*;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use vectorize_core::transformers::types::TransformerMetadata;
 use vectorize_core::types::{JobParams, TableMethod};
 
@@ -198,15 +198,17 @@ pub fn get_column_datatype(schema: &str, table: &str, column: &str) -> Result<St
             table_schema = $1
             AND table_name = $2
             AND column_name = $3    
-    ",
+        ",
         vec![
             (PgBuiltInOids::TEXTOID.oid(), schema.into_datum()),
             (PgBuiltInOids::TEXTOID.oid(), table.into_datum()),
             (PgBuiltInOids::TEXTOID.oid(), column.into_datum()),
         ],
-    )?
-    .context(format!(
-        "could not determine data type of column `{column}` on relation: `{schema}.{table}`"
-    ))
-    .context("no resultset for column datatype")
+    )
+    .map_err(|_|{
+        anyhow!("One of schema:`{}`, table:`{}`, column:`{}` does not exist", schema, table, column)
+    })?
+       .ok_or_else(|| {
+           anyhow!("Table `{schema}.{table}` is empty, does not exist, or column `{column}` does not exist.")
+       })
 }

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -205,10 +205,20 @@ pub fn get_column_datatype(schema: &str, table: &str, column: &str) -> Result<St
             (PgBuiltInOids::TEXTOID.oid(), column.into_datum()),
         ],
     )
-    .map_err(|_|{
-        anyhow!("One of schema:`{}`, table:`{}`, column:`{}` does not exist", schema, table, column)
+    .map_err(|_| {
+        anyhow!(
+            "One of schema:`{}`, table:`{}`, column:`{}` does not exist.",
+            schema,
+            table,
+            column
+        )
     })?
-       .ok_or_else(|| {
-           anyhow!("Table `{schema}.{table}` is empty, does not exist, or column `{column}` does not exist.")
-       })
+    .ok_or_else(|| {
+        anyhow!(
+            "Table `{}.{}` is empty, does not exist, or column `{}` does not exist.",
+            schema,
+            table,
+            column
+        )
+    })
 }


### PR DESCRIPTION
Before:
```
ERROR:  SpiTupleTable positioned before the start or after the end
```

After:
```
ERROR:  One of schema:`public`, table:`products`, column:`product_id` does not exist.
```