### PR TITLE
Update error handling for `vectorize.search()` when `vectorize.table()` not run beforehand

### DIFF
--- a/extension/src/chat/ops.rs
+++ b/extension/src/chat/ops.rs
@@ -22,8 +22,7 @@ pub fn call_chat(
     force_trim: bool,
 ) -> Result<ChatResponse> {
     // get job metadata
-    let project_meta: VectorizeMeta =
-        get_vectorize_meta_spi(agent_name)?.expect("project not found");
+    let project_meta: VectorizeMeta = get_vectorize_meta_spi(agent_name)?;
 
     let job_params = serde_json::from_value::<JobParams>(project_meta.params.clone())
         .unwrap_or_else(|e| error!("failed to deserialize job params: {}", e));

--- a/extension/src/job.rs
+++ b/extension/src/job.rs
@@ -20,7 +20,7 @@ fn _handle_table_update(job_name: &str, record_ids: Vec<String>, inputs: Vec<Str
     if record_ids.len() != inputs.len() {
         error!("record_ids and inputs must be the same length");
     }
-    let project_meta: VectorizeMeta = if let Ok(Some(js)) = util::get_vectorize_meta_spi(job_name) {
+    let project_meta: VectorizeMeta = if let Ok(js) = util::get_vectorize_meta_spi(job_name) {
         js
     } else {
         error!("failed to get project metadata");

--- a/extension/src/search.rs
+++ b/extension/src/search.rs
@@ -163,11 +163,7 @@ pub fn search(
     return_columns: Vec<String>,
     num_results: i32,
 ) -> Result<Vec<pgrx::JsonB>> {
-    let project_meta: VectorizeMeta = if let Ok(Some(js)) = util::get_vectorize_meta_spi(job_name) {
-        js
-    } else {
-        error!("Failed to get project metadata. Make sure `vectorize.table()` is run before vectorize.search()");
-    };
+    let project_meta: VectorizeMeta = util::get_vectorize_meta_spi(job_name)?;
     let proj_params: types::JobParams = serde_json::from_value(
         serde_json::to_value(project_meta.params).unwrap_or_else(|e| {
             error!("failed to serialize metadata: {}", e);

--- a/extension/src/search.rs
+++ b/extension/src/search.rs
@@ -166,7 +166,7 @@ pub fn search(
     let project_meta: VectorizeMeta = if let Ok(Some(js)) = util::get_vectorize_meta_spi(job_name) {
         js
     } else {
-        error!("failed to get project metadata");
+        error!("Failed to get project metadata. Make sure `vectorize.table()` is run before vectorize.search()");
     };
     let proj_params: types::JobParams = serde_json::from_value(
         serde_json::to_value(project_meta.params).unwrap_or_else(|e| {


### PR DESCRIPTION
Before
```
ERROR:  failed to get project metadata
```

Updated
```
ERROR:  project 'product_search_hf' not yet initialized. Please initialize the project.
```