### PR TITLE
fix model routing on transform_embeddings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @ChuckHend @DarrenBaldwin07 @samay-sharma
+*       @ChuckHend @samay-sharma

--- a/core/src/transformers/openai.rs
+++ b/core/src/transformers/openai.rs
@@ -7,7 +7,6 @@ use crate::types::{JobParams, VectorizeMeta};
 // however, depending on content of text, token count can be higher than
 pub const MAX_TOKEN_LEN: usize = 8192;
 pub const OPENAI_EMBEDDING_URL: &str = "https://api.openai.com/v1/embeddings";
-pub const OPENAI_EMBEDDING_MODEL: &str = "text-embedding-ada-002";
 
 pub fn prepare_openai_request(
     vect_meta: VectorizeMeta,
@@ -18,7 +17,7 @@ pub fn prepare_openai_request(
     let job_params: JobParams = serde_json::from_value(vect_meta.params.clone())?;
     let payload = EmbeddingPayload {
         input: text_inputs,
-        model: OPENAI_EMBEDDING_MODEL.to_owned(),
+        model: vect_meta.transformer.name.clone(),
     };
 
     let apikey = match job_params.api_key {

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorize"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 publish = false
 

--- a/extension/Trunk.toml
+++ b/extension/Trunk.toml
@@ -6,7 +6,7 @@ description = "The simplest way to orchestrate vector search on Postgres."
 homepage = "https://github.com/tembo-io/pg_vectorize"
 documentation = "https://github.com/tembo-io/pg_vectorize"
 categories = ["orchestration", "machine_learning"]
-version = "0.14.0"
+version = "0.14.1"
 
 [build]
 postgres_version = "15"

--- a/extension/src/transformers/mod.rs
+++ b/extension/src/transformers/mod.rs
@@ -7,7 +7,7 @@ use generic::get_generic_svc_url;
 use pgrx::prelude::*;
 
 use vectorize_core::transformers::http_handler::openai_embedding_request;
-use vectorize_core::transformers::openai::{OPENAI_EMBEDDING_MODEL, OPENAI_EMBEDDING_URL};
+use vectorize_core::transformers::openai::OPENAI_EMBEDDING_URL;
 use vectorize_core::transformers::types::{EmbeddingPayload, EmbeddingRequest};
 use vectorize_core::types::{Model, ModelSource};
 
@@ -32,7 +32,7 @@ pub fn transform(input: &str, transformer: &Model, api_key: Option<String>) -> V
 
             let embedding_request = EmbeddingPayload {
                 input: vec![input.to_string()],
-                model: OPENAI_EMBEDDING_MODEL.to_string(),
+                model: transformer.name.to_string(),
             };
             EmbeddingRequest {
                 url: OPENAI_EMBEDDING_URL.to_owned(),


### PR DESCRIPTION
`transform_embeddings()` was not respecting newly supported transformers