### PR TITLE
remove unused type

### DIFF
--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -86,41 +86,6 @@ impl From<String> for IndexDist {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum JobType {
-    Columns,
-    // row,
-    // url,
-}
-
-impl FromStr for JobType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Columns" => Ok(JobType::Columns),
-            _ => Err(format!("Invalid value: {}", s)),
-        }
-    }
-}
-
-impl From<String> for JobType {
-    fn from(s: String) -> Self {
-        match s.as_str() {
-            "Columns" => JobType::Columns,
-            _ => panic!("Invalid value for JobType: {}", s), // or handle this case differently
-        }
-    }
-}
-
-impl Display for JobType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match self {
-            JobType::Columns => write!(f, "Columns"),
-        }
-    }
-}
-
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TableMethod {
@@ -164,7 +129,6 @@ pub struct JobMessage {
 pub struct VectorizeMeta {
     pub job_id: i64,
     pub name: String,
-    pub job_type: JobType,
     pub index_dist_type: IndexDist,
     pub transformer: Model,
     // search_alg and SimilarityAlg are now deprecated

--- a/extension/.sqlx/query-d7a62ec23a0731cdd64bbfeca0345279a8a8660c2336a598fca0b81c26404da8.json
+++ b/extension/.sqlx/query-d7a62ec23a0731cdd64bbfeca0345279a8a8660c2336a598fca0b81c26404da8.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT *\n        FROM vectorize.job\n        WHERE name = $1\n        ",
+  "query": "\n        SELECT \n            job_id, name, index_dist_type, transformer, search_alg, params, last_completion\n        FROM vectorize.job\n        WHERE name = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -15,31 +15,26 @@
       },
       {
         "ordinal": 2,
-        "name": "job_type",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 3,
         "name": "index_dist_type",
         "type_info": "Text"
       },
       {
-        "ordinal": 4,
+        "ordinal": 3,
         "name": "transformer",
         "type_info": "Text"
       },
       {
-        "ordinal": 5,
+        "ordinal": 4,
         "name": "search_alg",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 5,
         "name": "params",
         "type_info": "Jsonb"
       },
       {
-        "ordinal": 7,
+        "ordinal": 6,
         "name": "last_completion",
         "type_info": "Timestamptz"
       }
@@ -56,9 +51,8 @@
       false,
       false,
       false,
-      false,
       true
     ]
   },
-  "hash": "406fb387c8a2d04c3a5362ae2da0154ff0295f078171f59b904e97fdd2933989"
+  "hash": "d7a62ec23a0731cdd64bbfeca0345279a8a8660c2336a598fca0b81c26404da8"
 }

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorize"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 publish = false
 

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -11,7 +11,7 @@ RUST_LOG:=debug
 .PHONY: install-pg_cron install-pg_vector install-pgmq run setup test-integration test-unit test-version test-branch test-upgrade cat-logs docs
 
 sqlx-cache:
-	cargo sqlx prepare
+	cargo sqlx prepare --database-url=${DATABASE_URL}
 
 format:
 	SQLX_OFFLINE=${SQLX_OFFLINE} cargo fmt --all

--- a/extension/Trunk.toml
+++ b/extension/Trunk.toml
@@ -6,7 +6,7 @@ description = "The simplest way to orchestrate vector search on Postgres."
 homepage = "https://github.com/tembo-io/pg_vectorize"
 documentation = "https://github.com/tembo-io/pg_vectorize"
 categories = ["orchestration", "machine_learning"]
-version = "0.15.0"
+version = "0.15.1"
 
 [build]
 postgres_version = "15"

--- a/extension/sql/meta.sql
+++ b/extension/sql/meta.sql
@@ -1,7 +1,6 @@
 CREATE TABLE vectorize.job (
     job_id bigserial,
     name TEXT NOT NULL UNIQUE,
-    job_type TEXT NOT NULL,
     index_dist_type TEXT NOT NULL DEFAULT 'pgv_hsnw_cosine',
     transformer TEXT NOT NULL,
     search_alg TEXT NOT NULL,

--- a/extension/sql/vectorize--0.15.0--0.15.1.sql
+++ b/extension/sql/vectorize--0.15.0--0.15.1.sql
@@ -1,0 +1,2 @@
+-- unused column
+ALTER TABLE vectorize.job DROP COLUMN job_type;

--- a/extension/src/executor.rs
+++ b/extension/src/executor.rs
@@ -111,7 +111,8 @@ pub async fn get_vectorize_meta(
     let row = sqlx::query_as!(
         VectorizeMeta,
         "
-        SELECT *
+        SELECT 
+            job_id, name, index_dist_type, transformer, search_alg, params, last_completion
         FROM vectorize.job
         WHERE name = $1
         ",

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -62,7 +62,7 @@ pub fn init_job_query() -> String {
     format!(
         "
         INSERT INTO {schema}.job (name, index_dist_type, transformer, search_alg, params)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (name) DO UPDATE SET
             index_dist_type = EXCLUDED.index_dist_type,
             search_alg = EXCLUDED.search_alg,

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -61,10 +61,9 @@ pub fn init_job_query() -> String {
     // search_alg is now deprecated
     format!(
         "
-        INSERT INTO {schema}.job (name, job_type, index_dist_type, transformer, search_alg, params)
+        INSERT INTO {schema}.job (name, index_dist_type, transformer, search_alg, params)
         VALUES ($1, $2, $3, $4, $5, $6)
         ON CONFLICT (name) DO UPDATE SET
-            job_type = EXCLUDED.job_type,
             index_dist_type = EXCLUDED.index_dist_type,
             search_alg = EXCLUDED.search_alg,
             params = job.params || EXCLUDED.params;

--- a/extension/src/job.rs
+++ b/extension/src/job.rs
@@ -9,7 +9,7 @@ use pgrx::prelude::*;
 use tiktoken_rs::cl100k_base;
 use vectorize_core::transformers::types::Inputs;
 use vectorize_core::types::{
-    IndexDist, JobMessage, JobParams, JobType, Model, SimilarityAlg, TableMethod, VectorizeMeta,
+    IndexDist, JobMessage, JobParams, Model, SimilarityAlg, TableMethod, VectorizeMeta,
 };
 
 /// called by the trigger function when a table is updated
@@ -126,7 +126,6 @@ fn generate_select_cols(inputs: &[String]) -> String {
 pub fn initalize_table_job(
     job_name: &str,
     job_params: &JobParams,
-    job_type: &JobType,
     index_dist_type: IndexDist,
     transformer: &Model,
     // search_alg is now deprecated
@@ -164,7 +163,6 @@ pub fn initalize_table_job(
         // TODO: in future, lookup job id once this gets put into use
         // job_id is currently not used, job_name is unique
         job_id: 0,
-        job_type: job_type.clone(),
         params: serde_json::to_value(job_params.clone()).unwrap(),
         index_dist_type: index_dist_type.clone(),
         transformer: transformer.clone(),

--- a/extension/src/search.rs
+++ b/extension/src/search.rs
@@ -27,8 +27,6 @@ pub fn init_table(
     // cron-like for a cron based update model, or 'realtime' for a trigger-based
     schedule: &str,
 ) -> Result<String> {
-    let job_type = types::JobType::Columns;
-
     // validate table method
     // realtime is only compatible with the join method
     if schedule == "realtime" && table_method != TableMethod::join {
@@ -102,10 +100,6 @@ pub fn init_table(
                 (PgBuiltInOids::TEXTOID.oid(), job_name.into_datum()),
                 (
                     PgBuiltInOids::TEXTOID.oid(),
-                    job_type.to_string().into_datum(),
-                ),
-                (
-                    PgBuiltInOids::TEXTOID.oid(),
                     index_dist_type.to_string().into_datum(),
                 ),
                 (
@@ -165,7 +159,6 @@ pub fn init_table(
     initalize_table_job(
         job_name,
         &valid_params,
-        &job_type,
         index_dist_type,
         transformer,
         // search_alg is now deprecated

--- a/extension/src/util.rs
+++ b/extension/src/util.rs
@@ -67,7 +67,6 @@ pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
         SELECT 
             job_id,
             name,
-            job_type,
             index_dist_type,
             transformer,
             search_alg,
@@ -97,10 +96,6 @@ pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
             .get_by_name("name")
             .expect("name column does not exist.")
             .expect("name column was null.");
-        let job_type: String = result_row
-            .get_by_name("job_type")
-            .expect("job_type column does not exist.")
-            .expect("job_type column was null.");
         let index_dist_type: String = result_row
             .get_by_name("index_dist_type")
             .expect("index_dist_type column does not exist.")
@@ -123,7 +118,6 @@ pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
         Ok(types::VectorizeMeta {
             job_id,
             name,
-            job_type: job_type.into(),
             index_dist_type: index_dist_type.into(),
             transformer: transformer_model,
             // search_alg is now deprecated


### PR DESCRIPTION
job_type is an enum with a single variant. There are no plans to add additional variants to this type. Removing it to reduce confusion.