### PR TITLE
trigger vector serve builds

### DIFF
--- a/.github/workflows/build-vector-serve.yml
+++ b/.github/workflows/build-vector-serve.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths:
       - ".github/workflows/build-vector-serve.yml"
-      - "./vector-serve/**/*"
+      - "./vector-serve/**"
 
   pull_request:
     branches:
       - main
     paths:
       - ".github/workflows/build-vector-serve.yml"
-      - "./vector-serve/**/*"
+      - "./vector-serve/**"
 
 permissions:
   id-token: write


### PR DESCRIPTION
https://github.com/tembo-io/pg_vectorize/pull/115 did not build. Possibly due to how the trigger criteria is set on the workflow.