### PR TITLE
fix and rename project views

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -248,5 +248,3 @@ jobs:
           tags: |
             quay.io/tembo/vectorize-pg:v${{ steps.versions.outputs.TAG_VER }}
             quay.io/tembo/vectorize-pg:latest
-            ghcr.io/tembo-io/vectorize-pg-v${{ steps.versions.outputs.TAG_VER }}
-            ghcr.io/tembo-io/vectorize-pg:latest

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.11.3"
 lazy_static = "1.4.0"
 log = "0.4.21"
 ollama-rs = "0.2"
-pgmq = "0.26.1"
+pgmq = "0.29"
 regex = "1.9.2"
 reqwest = {version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.173", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ chrono = {version = "0.4.26", features = ["serde"] }
 env_logger = "0.11.3"
 lazy_static = "1.4.0"
 log = "0.4.21"
-ollama-rs = "0.2"
+ollama-rs = "=0.2.1"
 pgmq = "0.29"
 regex = "1.9.2"
 reqwest = {version = "0.11.18", features = ["json"] }

--- a/core/src/bin/worker.rs
+++ b/core/src/bin/worker.rs
@@ -20,9 +20,7 @@ async fn main() {
         .await
         .expect("unable to initialize extension");
 
-    let queue = pgmq::PGMQueueExt::new_with_pool(conn.clone())
-        .await
-        .unwrap();
+    let queue = pgmq::PGMQueueExt::new_with_pool(conn.clone()).await;
 
     loop {
         match poll_job(&conn, &queue, &cfg).await {

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -20,7 +20,7 @@ chrono = {version = "0.4.26", features = ["serde"] }
 handlebars = "5.1.0"
 lazy_static = "1.4.0"
 log = "0.4.21"
-pgmq = "0.26.1"
+pgmq = "0.29"
 pgrx = "0.11.4"
 postgres-types = "0.2.5"
 regex = "1.9.2"

--- a/extension/src/executor.rs
+++ b/extension/src/executor.rs
@@ -57,8 +57,7 @@ fn job_execute(job_name: String) {
         let conn = get_pg_conn()
             .await
             .unwrap_or_else(|e| error!("pg-vectorize: failed to establish db connection: {}", e));
-        let queue = pgmq::PGMQueueExt::new_with_pool(conn.clone())
-            .await;
+        let queue = pgmq::PGMQueueExt::new_with_pool(conn.clone()).await;
         let meta = get_vectorize_meta(&job_name, &conn)
             .await
             .unwrap_or_else(|e| error!("failed to get job metadata: {}", e));

--- a/extension/src/executor.rs
+++ b/extension/src/executor.rs
@@ -58,8 +58,7 @@ fn job_execute(job_name: String) {
             .await
             .unwrap_or_else(|e| error!("pg-vectorize: failed to establish db connection: {}", e));
         let queue = pgmq::PGMQueueExt::new_with_pool(conn.clone())
-            .await
-            .unwrap_or_else(|e| error!("failed to init db connection: {}", e));
+            .await;
         let meta = get_vectorize_meta(&job_name, &conn)
             .await
             .unwrap_or_else(|e| error!("failed to get job metadata: {}", e));

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -64,7 +64,7 @@ pub fn init_job_query() -> String {
 
 fn drop_project_view(job_name: &str) -> String {
     format!(
-        "DROP VIEW IF EXISTS vectorize.{job_name};",
+        "DROP VIEW IF EXISTS vectorize.{job_name}_view;",
         job_name = job_name
     )
 }

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -62,10 +62,17 @@ pub fn init_job_query() -> String {
     )
 }
 
+fn drop_project_view(job_name: &str) -> String {
+    format!(
+        "DROP VIEW IF EXISTS vectorize.{job_name};",
+        job_name = job_name
+    )
+}
+
 /// creates a project view over a source table and the embeddings table
 fn create_project_view(job_name: &str, job_params: &JobParams) -> String {
     format!(
-        "CREATE OR REPLACE VIEW vectorize.{job_name} as 
+        "CREATE VIEW vectorize.{job_name}_view as 
         SELECT t0.*, t1.embeddings, t1.updated_at as embeddings_updated_at
         FROM {schema}.{table} t0
         INNER JOIN vectorize._embeddings_{job_name} t1
@@ -140,6 +147,7 @@ pub fn init_embedding_table_query(
                 ),
                 index_stmt,
                 // also create a view over the source table and the embedding table, for this project
+                drop_project_view(job_name),
                 create_project_view(job_name, job_params),
             ]
         }

--- a/extension/src/workers/pg_bgw.rs
+++ b/extension/src/workers/pg_bgw.rs
@@ -48,7 +48,7 @@ pub extern "C" fn background_worker_main(_arg: pg_sys::Datum) {
     let mut wait_duration: Duration = Duration::from_secs(6);
     while BackgroundWorker::wait_latch(Some(wait_duration)) {
         if !ext_ready {
-            warning!("pg-vectorize: waiting for CREATE EXTENSION vectorize CASCADE;");
+            debug5!("pg-vectorize-bgw: waiting for first pg-vectorize job to be created");
             runtime.block_on(async {
                 ext_ready = ready(&conn).await;
             });

--- a/extension/src/workers/pg_bgw.rs
+++ b/extension/src/workers/pg_bgw.rs
@@ -36,8 +36,7 @@ pub extern "C" fn background_worker_main(_arg: pg_sys::Datum) {
     // specify database
     let (conn, queue) = runtime.block_on(async {
         let con = get_pg_conn().await.expect("failed to connect to database");
-        let queue = pgmq::PGMQueueExt::new_with_pool(con.clone())
-            .await;
+        let queue = pgmq::PGMQueueExt::new_with_pool(con.clone()).await;
         (con, queue)
     });
 

--- a/extension/src/workers/pg_bgw.rs
+++ b/extension/src/workers/pg_bgw.rs
@@ -37,8 +37,7 @@ pub extern "C" fn background_worker_main(_arg: pg_sys::Datum) {
     let (conn, queue) = runtime.block_on(async {
         let con = get_pg_conn().await.expect("failed to connect to database");
         let queue = pgmq::PGMQueueExt::new_with_pool(con.clone())
-            .await
-            .expect("failed to init db connection");
+            .await;
         (con, queue)
     });
 

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -451,7 +451,7 @@ async fn test_realtime_tabled() {
 
     // `join` method must have a view created
     let select = format!(
-        "SELECT product_id, product_name, description, embeddings, embeddings_updated_at FROM vectorize.{job_name}"
+        "SELECT product_id, product_name, description, embeddings, embeddings_updated_at FROM vectorize.{job_name}_view"
     );
     let result = sqlx::query(&select)
         .fetch_all(&conn)


### PR DESCRIPTION
- bug fix - adding a column to a source table causes subsequent `vectorize.table()` calls to fail when attempting to update the project's view. Fixing this by dropping and replacing the view instead of using `create or replace`.

Also:
- adding a `_view` suffix to the view to make it more obvious to users and making the initialization log more descriptive.
- updating pgmq and ollama-rs crate versions