### PR TITLE
CONTRIBUTING.md: Fix setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,12 @@ rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
 ```bash
 git clone https://github.com/tembo-io/pg_vectorize.git
 
-cd pg_vectorize
+cd pg_vectorize/extension
 ```
 
 #### 3.3. Install dependencies
 
-From within the pg_vectorize directory, run the following, which will install `pg_cron`, `pgmq`, and `pgvector`:
+From within the pg_vectorize/extension directory, run the following, which will install `pg_cron`, `pgmq`, and `pgvector`:
 
 ```bash
 make setup


### PR DESCRIPTION
Hi, the current doc doesn't mention the full path to the Makefile that is supposed to be run, which is in the extension subdirectory and it misleads the reader into running `make setup` and `make run` from the project root which fails