### PR TITLE
Enhance vectorize.table() to support chunking

### DIFF
--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -5,6 +5,7 @@ use crate::search::{self, init_table};
 use crate::transformers::generic::env_interpolate_string;
 use crate::transformers::transform;
 use crate::types;
+use crate::util::*;
 
 use anyhow::Result;
 use pgrx::prelude::*;
@@ -21,17 +22,29 @@ fn table(
     update_col: default!(String, "'last_updated_at'"),
     index_dist_type: default!(types::IndexDist, "'pgv_hnsw_cosine'"),
     transformer: default!(&str, "'sentence-transformers/all-MiniLM-L6-v2'"),
+    chunk_size: default!(Option<i32>, "NULL"),
+    chunk_overlap: default!(Option<i32>, "NULL"),
     // search_alg is now deprecated
     search_alg: default!(types::SimilarityAlg, "'pgv_cosine_similarity'"),
     table_method: default!(types::TableMethod, "'join'"),
     // cron-like for a cron based update model, or 'realtime' for a trigger-based
     schedule: default!(&str, "'* * * * *'"),
 ) -> Result<String> {
+    let chunked_table_name = format!("{}_chunked", table);
+    chunk_table(
+        table,
+        columns.clone(),
+        chunk_size.unwrap_or(1000),
+        chunk_overlap.unwrap_or(200),
+        &chunked_table_name,
+        schema,
+    )?;
+
     let model = Model::new(transformer)?;
     init_table(
         job_name,
         schema,
-        table,
+        &chunked_table_name,
         columns,
         primary_key,
         Some(update_col),
@@ -42,6 +55,45 @@ fn table(
         table_method.into(),
         schedule,
     )
+}
+
+/// Utility function to chunk the rows of a table and store them in a new table
+#[pg_extern]
+async fn chunk_table(
+    input_table: &str,
+    columns: Vec<String>,
+    chunk_size: default!(i32, 1000),
+    chunk_overlap: default!(i32, 200),
+    output_table: &str,
+    schema: default!(&str, "'public'"),
+) -> Result<String> {
+    let conn = get_pg_conn().await?;
+
+    let rows = fetch_table_rows(&conn, input_table, columns.clone(), schema).await?;
+    create_chunked_table(output_table, columns.clone(), schema)?;
+
+    for row in rows {
+        for col in &columns {
+            if let Some(text) = row.get(col) {
+                let chunks =
+                    chunking::chunk_text(text, chunk_size as usize, chunk_overlap as usize);
+                // Insert each chunk as a new row in the output table
+                for chunk in chunks {
+                    insert_chunk_into_table(
+                        output_table,
+                        chunk,
+                        row.get("primary_key").unwrap(),
+                        schema,
+                    )?;
+                }
+            }
+        }
+    }
+
+    Ok(format!(
+        "Data from {} successfully chunked into {}",
+        input_table, output_table
+    ))
 }
 
 #[pg_extern]

--- a/extension/src/util.rs
+++ b/extension/src/util.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use pgrx::spi::SpiTupleTable;
 use pgrx::*;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-use sqlx::{Pool, Postgres};
+use sqlx::{Pool, Postgres, Row};
 use std::env;
 use url::{ParseError, Url};
 
@@ -220,4 +220,51 @@ pub async fn ready(conn: &Pool<Postgres>) -> bool {
     .fetch_one(conn)
     .await
     .expect("failed")
+}
+
+/// Recursive split text based on separators
+pub fn chunk_text(text: &str, chunk_size: usize, chunk_overlap: usize) -> Vec<String> {
+    let separators = vec!["\n\n", "\n", " ", ""];
+    let mut chunks = Vec::new();
+    let mut start = 0;
+
+    while start < text.len() {
+        let mut chunk_found = false;
+
+        // Try to split the text based on the separators
+        for sep in &separators {
+            let end_pos = text[start..].find(sep).unwrap_or(text.len());
+
+            if end_pos - start >= chunk_size {
+                let chunk = &text[start..start + chunk_size].to_string();
+                chunks.push(chunk.clone());
+                start += chunk_size - chunk_overlap;
+                chunk_found = true;
+                break;
+            }
+        }
+
+        // Fallback if no suitable separator is found, chunk by size
+        if !chunk_found {
+            let end = std::cmp::min(start + chunk_size, text.len());
+            chunks.push(text[start..end].to_string());
+            start += chunk_size - chunk_overlap;
+        }
+    }
+
+    chunks
+}
+
+/// Fetch rows from a given table and schema
+pub async fn fetch_table_rows(
+    conn: &Pool<Postgres>,
+    table: &str,
+    columns: Vec<String>,
+    schema: &str,
+) -> Result<Vec<sqlx::postgres::PgRow>> {
+    let query = format!("SELECT {} FROM {}.{}", columns.join(", "), schema, table);
+
+    // Execute the query using sqlx and fetch the rows
+    let rows = sqlx::query(&query).fetch_all(conn).await?;
+    Ok(rows)
 }


### PR DESCRIPTION
What does this PR do?

This PR adds support for chunking text in input columns for the `vectorize.table` function, enhancing document subset retrieval.

/fixes #142 
/claim #142