### PR TITLE
Remove outdated parameters from vectorize.table()

### DIFF
--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -137,8 +137,6 @@ pub struct VectorizeMeta {
     pub name: String,
     pub index_dist_type: IndexDist,
     pub transformer: Model,
-    // search_alg and SimilarityAlg are now deprecated
-    pub search_alg: SimilarityAlg,
     pub params: serde_json::Value,
     #[serde(deserialize_with = "from_tsopt")]
     pub last_completion: Option<chrono::DateTime<Utc>>,

--- a/extension/.sqlx/query-d7a62ec23a0731cdd64bbfeca0345279a8a8660c2336a598fca0b81c26404da8.json
+++ b/extension/.sqlx/query-d7a62ec23a0731cdd64bbfeca0345279a8a8660c2336a598fca0b81c26404da8.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT \n            job_id, name, index_dist_type, transformer, search_alg, params, last_completion\n        FROM vectorize.job\n        WHERE name = $1\n        ",
+  "query": "\n        SELECT \n            job_id, name, index_dist_type, transformer, params, last_completion\n        FROM vectorize.job\n        WHERE name = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -25,16 +25,11 @@
       },
       {
         "ordinal": 4,
-        "name": "search_alg",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 5,
         "name": "params",
         "type_info": "Jsonb"
       },
       {
-        "ordinal": 6,
+        "ordinal": 5,
         "name": "last_completion",
         "type_info": "Timestamptz"
       }
@@ -45,7 +40,6 @@
       ]
     },
     "nullable": [
-      false,
       false,
       false,
       false,

--- a/extension/sql/meta.sql
+++ b/extension/sql/meta.sql
@@ -3,7 +3,6 @@ CREATE TABLE vectorize.job (
     name TEXT NOT NULL UNIQUE,
     index_dist_type TEXT NOT NULL DEFAULT 'pgv_hsnw_cosine',
     transformer TEXT NOT NULL,
-    search_alg TEXT NOT NULL,
     params jsonb NOT NULL,
     last_completion TIMESTAMP WITH TIME ZONE
 );

--- a/extension/sql/vectorize--0.19.1--0.20.0.sql
+++ b/extension/sql/vectorize--0.19.1--0.20.0.sql
@@ -1,0 +1,34 @@
+ALTER TABLE vectorize.job DROP COLUMN search_alg;
+
+DROP FUNCTION IF EXISTS vectorize."table";
+CREATE FUNCTION vectorize."table"(
+    "table" TEXT,
+    "columns" TEXT[],
+    "job_name" TEXT,
+    "primary_key" TEXT,
+    "schema" TEXT DEFAULT 'public',
+    "update_col" TEXT DEFAULT 'last_updated_at',
+    "index_dist_type" vectorize.IndexDist DEFAULT 'pgv_hnsw_cosine',
+    "transformer" TEXT DEFAULT 'sentence-transformers/all-MiniLM-L6-v2',
+    "table_method" vectorize.TableMethod DEFAULT 'join',
+    "schedule" TEXT DEFAULT '* * * * *'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'table_wrapper';
+
+DROP FUNCTION IF EXISTS vectorize."init_rag";
+CREATE FUNCTION vectorize."init_rag"(
+    "agent_name" TEXT,
+    "table_name" TEXT,
+    "unique_record_id" TEXT,
+    "column" TEXT,
+    "schema" TEXT DEFAULT 'public',
+    "index_dist_type" vectorize.IndexDist DEFAULT 'pgv_hnsw_cosine',
+    "transformer" TEXT DEFAULT 'sentence-transformers/all-MiniLM-L6-v2',
+    "table_method" vectorize.TableMethod DEFAULT 'join',
+    "schedule" TEXT DEFAULT '* * * * *'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'init_rag_wrapper';

--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -21,8 +21,6 @@ fn table(
     update_col: default!(String, "'last_updated_at'"),
     index_dist_type: default!(types::IndexDist, "'pgv_hnsw_cosine'"),
     transformer: default!(&str, "'sentence-transformers/all-MiniLM-L6-v2'"),
-    // search_alg is now deprecated
-    search_alg: default!(types::SimilarityAlg, "'pgv_cosine_similarity'"),
     table_method: default!(types::TableMethod, "'join'"),
     // cron-like for a cron based update model, or 'realtime' for a trigger-based
     schedule: default!(&str, "'* * * * *'"),
@@ -37,8 +35,6 @@ fn table(
         Some(update_col),
         index_dist_type.into(),
         &model,
-        // search_alg is now deprecated
-        search_alg.into(),
         table_method.into(),
         schedule,
     )
@@ -96,9 +92,6 @@ fn init_rag(
     index_dist_type: default!(types::IndexDist, "'pgv_hnsw_cosine'"),
     // transformer model to use in vector-search
     transformer: default!(&str, "'sentence-transformers/all-MiniLM-L6-v2'"),
-    // similarity algorithm to use in vector-search
-    // search_alg is now deprecated
-    search_alg: default!(types::SimilarityAlg, "'pgv_cosine_similarity'"),
     table_method: default!(types::TableMethod, "'join'"),
     schedule: default!(&str, "'* * * * *'"),
 ) -> Result<String> {
@@ -114,8 +107,6 @@ fn init_rag(
         None,
         index_dist_type.into(),
         &transformer_model,
-        // search_alg is now deprecated
-        search_alg.into(),
         table_method.into(),
         schedule,
     )

--- a/extension/src/executor.rs
+++ b/extension/src/executor.rs
@@ -110,7 +110,7 @@ pub async fn get_vectorize_meta(
         VectorizeMeta,
         "
         SELECT 
-            job_id, name, index_dist_type, transformer, search_alg, params, last_completion
+            job_id, name, index_dist_type, transformer, params, last_completion
         FROM vectorize.job
         WHERE name = $1
         ",

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -48,14 +48,12 @@ pub fn init_cron(cron: &str, job_name: &str) -> Result<Option<i64>, spi::Error> 
 
 pub fn init_job_query() -> String {
     // params is jsonb. conduct a merge on conflict instead of a overwrite
-    // search_alg is now deprecated
     format!(
         "
-        INSERT INTO {schema}.job (name, index_dist_type, transformer, search_alg, params)
-        VALUES ($1, $2, $3, $4, $5)
+        INSERT INTO {schema}.job (name, index_dist_type, transformer, params)
+        VALUES ($1, $2, $3, $4)
         ON CONFLICT (name) DO UPDATE SET
             index_dist_type = EXCLUDED.index_dist_type,
-            search_alg = EXCLUDED.search_alg,
             params = job.params || EXCLUDED.params;
         ",
         schema = types::VECTORIZE_SCHEMA

--- a/extension/src/job.rs
+++ b/extension/src/job.rs
@@ -9,7 +9,7 @@ use pgrx::prelude::*;
 use tiktoken_rs::cl100k_base;
 use vectorize_core::transformers::types::Inputs;
 use vectorize_core::types::{
-    IndexDist, JobMessage, JobParams, Model, SimilarityAlg, TableMethod, VectorizeMeta,
+    IndexDist, JobMessage, JobParams, Model,TableMethod, VectorizeMeta,
 };
 
 /// called by the trigger function when a table is updated
@@ -128,8 +128,6 @@ pub fn initalize_table_job(
     job_params: &JobParams,
     index_dist_type: IndexDist,
     transformer: &Model,
-    // search_alg is now deprecated
-    search_alg: SimilarityAlg,
 ) -> Result<()> {
     // start with initial batch load
     let rows_need_update_query: String = match job_params.table_method {
@@ -166,8 +164,6 @@ pub fn initalize_table_job(
         params: serde_json::to_value(job_params.clone()).unwrap(),
         index_dist_type: index_dist_type.clone(),
         transformer: transformer.clone(),
-        // search_alg is now deprecated
-        search_alg: search_alg.clone(),
         last_completion: None,
     };
     for b in batches {

--- a/extension/src/search.rs
+++ b/extension/src/search.rs
@@ -22,8 +22,6 @@ pub fn init_table(
     update_col: Option<String>,
     index_dist_type: types::IndexDist,
     transformer: &Model,
-    // search_alg is now deprecated
-    search_alg: types::SimilarityAlg,
     table_method: types::TableMethod,
     // cron-like for a cron based update model, or 'realtime' for a trigger-based
     schedule: &str,
@@ -133,11 +131,6 @@ pub fn init_table(
                     PgBuiltInOids::TEXTOID.oid(),
                     transformer.to_string().into_datum(),
                 ),
-                (
-                    PgBuiltInOids::TEXTOID.oid(),
-                    // search_alg is now deprecated
-                    search_alg.to_string().into_datum(),
-                ),
                 (PgBuiltInOids::JSONBOID.oid(), params.into_datum()),
             ]),
         ) {
@@ -188,8 +181,6 @@ pub fn init_table(
         &valid_params,
         index_dist_type,
         transformer,
-        // search_alg is now deprecated
-        search_alg,
     )?;
     Ok(format!("Successfully created job: {job_name}"))
 }

--- a/extension/src/util.rs
+++ b/extension/src/util.rs
@@ -62,14 +62,12 @@ pub fn from_env_default(key: &str, default: &str) -> String {
 }
 
 pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
-    // search_alg is now deprecated
     let query: &str = "
         SELECT 
             job_id,
             name,
             index_dist_type,
             transformer,
-            search_alg,
             params
         FROM vectorize.job
         WHERE name = $1
@@ -104,11 +102,6 @@ pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
             .get_by_name("transformer")
             .expect("transformer column does not exist.")
             .expect("transformer column was null.");
-        // search_alg is now deprecated
-        let search_alg: String = result_row
-            .get_by_name("search_alg")
-            .expect("search_alg column does not exist.")
-            .expect("search_alg column was null.");
         let params: pgrx::JsonB = result_row
             .get_by_name("params")
             .expect("params column does not exist.")
@@ -120,8 +113,6 @@ pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
             name,
             index_dist_type: index_dist_type.into(),
             transformer: transformer_model,
-            // search_alg is now deprecated
-            search_alg: search_alg.into(),
             params: serde_json::to_value(params).unwrap(),
             last_completion: None,
         })


### PR DESCRIPTION
What does this PR do?

This PR adds support for chunking text in input columns for the `vectorize.table` function, enhancing document subset retrieval.

/fixes #146 
/claim #146 