### PR TITLE
CONTRIBUTING.md: Add missing information regarding enabling extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,12 @@ make run
 
 Once the above command is run, you will be brought into Postgres via `psql`.
 
+Run the following command inside the `psql` console to enable the extensions:
+
+```sql
+create extension vectorize cascade
+```
+
 To list out the enabled extensions, run:
 
 ```sql


### PR DESCRIPTION
Hi, i followed the steps in the contributing guide but upon listing the extensions I could only find the default one enabled

```
                 List of installed extensions
  Name   | Version |   Schema   |         Description          
---------+---------+------------+------------------------------
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
(1 row)

```

The guide was missing the `CREATE EXTENSION` command which fixes this. I have added them to the doc