### PR TITLE
only pass hf tokens

### DIFF
--- a/vector-serve/app/models.py
+++ b/vector-serve/app/models.py
@@ -26,9 +26,14 @@ except Exception:
     MULTI_MODEL = 1
 
 
-def parse_header(authorization: str) -> str | None:
+def parse_header(authorization: str | None) -> str | None:
+    """parses hugging face token from the authorization header
+    Returns None if the token is not a hugging face token"""
     if authorization is not None:
-        return authorization.split("Bearer ")[-1]
+        token_value = authorization.split("Bearer ")[-1]
+        is_hf_token = bool(token_value and token_value.startswith("hf_"))
+        if is_hf_token:
+            return token_value
     return None
 
 
@@ -70,9 +75,8 @@ def get_model(
         # and model not in cache
         logging.debug(f"Model: {model_name} not in cache.")
         try:
-            logging.error("api_key: %s", api_key)
             model = SentenceTransformer(
-                model_name, use_auth_token=api_key, trust_remote_code=True
+                model_name, token=api_key, trust_remote_code=True
             )
             # add model to cache
             model_cache[model_name] = model

--- a/vector-serve/app/routes/transform.py
+++ b/vector-serve/app/routes/transform.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel, conlist
 
 router = APIRouter(tags=["transform"])
 
-logging.basicConfig(level=logging.DEBUG)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=LOG_LEVEL)
 
 BATCH_SIZE = int(os.getenv("BATCH_SIZE", 1000))
 

--- a/vector-serve/tests/conftest.py
+++ b/vector-serve/tests/conftest.py
@@ -3,6 +3,7 @@ from starlette.testclient import TestClient
 
 from app.app import app
 
+
 @pytest.fixture()
 def test_client():
     with TestClient(app) as test_client:

--- a/vector-serve/tests/test_endpoints.py
+++ b/vector-serve/tests/test_endpoints.py
@@ -1,18 +1,19 @@
-from fastapi.testclient import TestClient
-from fastapi import FastAPI
-
 def test_ready_endpoint(test_client):
     response = test_client.get("/ready")
     assert response.status_code == 200
     assert response.json() == {"ready": True}
+
 
 def test_alive_endpoint(test_client):
     response = test_client.get("/alive")
     assert response.status_code == 200
     assert response.json() == {"alive": True}
 
+
 def test_model_info(test_client):
-    response = test_client.get("/v1/info", params={"model_name": "sentence-transformers/all-MiniLM-L6-v2"})
+    response = test_client.get(
+        "/v1/info", params={"model_name": "sentence-transformers/all-MiniLM-L6-v2"}
+    )
     assert response.status_code == 200
 
 


### PR DESCRIPTION
Fixes issue related to https://github.com/UKPLab/sentence-transformers/issues/3212. Only passes a value for `token` if it is a valid hf token, assuming if the value begins with `hf_`then it is valid.

Also:
- change parameter from `use_auth_token` to `token` to resolve deprecation warning
- make log level configurable with `LOG_LEVEL` env var