### PR TITLE
cron needs last_updated_at

### DIFF
--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -395,6 +395,12 @@ fn table_from(
 ) -> Result<String> {
     let model = Model::new(transformer)?;
 
+    let update_time_col = if schedule == "realtime" {
+        // updates are based on triggers in the realtime configuration
+        None
+    } else {
+        Some(update_col)
+    };
     // First initialize the table structure without triggers/cron
     init_table(
         job_name,
@@ -402,7 +408,7 @@ fn table_from(
         table,
         columns.clone(),
         primary_key,
-        Some(update_col),
+        update_time_col,
         index_dist_type.into(),
         &model,
         table_method.into(),

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -1351,7 +1351,8 @@ async fn test_table_from() {
     sqlx::query(&format!(
         "CREATE TABLE {} (
             id SERIAL PRIMARY KEY,
-            content TEXT
+            content TEXT,
+            last_updated_at TIMESTAMPTZ DEFAULT NOW()
         )",
         dest_table_name
     ))


### PR DESCRIPTION
quick follow-up fix to https://github.com/tembo-io/pg_vectorize/pull/199 to:
- update test to add `last_update_at` in the cron test
- set `update_col` param to `None` when `table_from(schedule=>'realtime',...)`