### PR TITLE
Refactor: rename table parameter to relation in table() function 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ SELECT * FROM products limit 2;
 ```sql
 SELECT vectorize.table(
 job_name => 'product_search_hf',
-"table" => 'products',
+relation => 'products',
 primary_key => 'product_id',
 columns => ARRAY['product_name', 'description'],
 transformer => 'sentence-transformers/multi-qa-MiniLM-L6-dot-v1'

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -104,7 +104,7 @@ pub enum TableMethod {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, FromRow)]
 pub struct JobParams {
     pub schema: String,
-    pub table: String,
+    pub relation: String,
     pub columns: Vec<String>,
     pub update_time_col: Option<String>,
     pub table_method: TableMethod,

--- a/core/src/worker/base.rs
+++ b/core/src/worker/base.rs
@@ -119,7 +119,7 @@ async fn execute_job(
             ops::update_embeddings(
                 dbclient,
                 &job_params.schema,
-                &job_params.table,
+                &job_params.relation,
                 &job_meta.clone().name,
                 &job_params.primary_key,
                 &job_params.pkey_type,

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -36,7 +36,7 @@ The embeddings must match the dimensions expected by the model specified when cr
 -- First create a vectorize project
 SELECT vectorize.table(
     job_name => 'product_search',
-    table => 'products',
+    relation => 'products',
     primary_key => 'id',
     columns => ARRAY['description'],
     transformer => 'sentence-transformers/all-MiniLM-L6-v2'
@@ -57,7 +57,7 @@ If you have pre-computed embeddings and want to create a new vectorize table fro
 
 ```sql
 SELECT vectorize.table_from(
-    table => 'products',
+    relation => 'products',
     columns => ARRAY['description'],
     job_name => 'product_search',
     primary_key => 'id',
@@ -78,7 +78,7 @@ The embeddings must match the dimensions of the specified transformer model.
 
 ### Parameters
 
-- `table`: The table to create or modify
+- `relation`: The table to create or modify
 - `columns`: Array of columns to generate embeddings from
 - `job_name`: Name for this vectorize project
 - `primary_key`: Primary key column in your table

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -8,7 +8,7 @@ Initialize a table for vector search. Generates embeddings and index. Creates tr
 
 ```sql
 vectorize."table"(
-    "table" TEXT,
+    "relation" TEXT,
     "columns" TEXT[],
     "job_name" TEXT,
     "primary_key" TEXT,
@@ -23,7 +23,7 @@ vectorize."table"(
 
 | Parameter      | Type | Description     |
 | :---        |    :----   |          :--- |
-| table | text | The name of the table to be initialized. |
+| relation | text | The name of the table to be initialized. |
 | columns | text | The name of the columns that contains the content that is used for context for RAG. Multiple columns are concatenated. |
 | job_name | text | A unique name for the project. |
 | primary_key | text | The name of the column that contains the unique record id. |
@@ -47,7 +47,7 @@ Pass the API key into the function call via `args`.
 ```sql
 select vectorize.table(
     job_name    => 'product_search',
-    "table"     => 'products',
+    relation    => 'products',
     primary_key => 'product_id',
     columns     => ARRAY['product_name', 'description'],
     transformer =>  'openai/text-embedding-ada-002',
@@ -67,7 +67,7 @@ Then call `vectorize.table()` without providing the API key.
 ```sql
 select vectorize.table(
     job_name    => 'product_search',
-    "table"     => 'products',
+    relation    => 'products',
     primary_key => 'product_id',
     columns     => ARRAY['product_name', 'description'],
     transformer =>  'openai/text-embedding-ada-002'

--- a/docs/examples/openai_embeddings.md
+++ b/docs/examples/openai_embeddings.md
@@ -23,7 +23,7 @@ Then create the job.
 ```sql
 SELECT vectorize.table(
     job_name    => 'product_search_openai',
-    "table"     => 'products',
+    relation    => 'products',
     primary_key => 'product_id',
     columns     => ARRAY['product_name', 'description'],
     transformer => 'openai/text-embedding-ada-002'

--- a/docs/examples/sentence_transformers.md
+++ b/docs/examples/sentence_transformers.md
@@ -54,7 +54,7 @@ Create a job to vectorize the products table. We'll specify the tables primary k
 ```sql
 SELECT vectorize.table(
     job_name    => 'product_search_hf',
-    "table"     => 'products',
+    relation    => 'products',
     primary_key => 'product_id',
     columns     => ARRAY['product_name', 'description'],
     transformer => 'sentence-transformers/multi-qa-MiniLM-L6-dot-v1',

--- a/extension/sql/meta.sql
+++ b/extension/sql/meta.sql
@@ -34,7 +34,7 @@ BEGIN
             
             -- Perform cleanup: delete the associated job from the vectorize.job table
             DELETE FROM vectorize.job
-            WHERE params ->> 'table' = table_name
+            WHERE params ->> 'relation' = table_name
             AND params ->> 'schema' = schema_name;
         END IF;
     END LOOP;

--- a/extension/sql/vectorize--0.21.1--0.22.0.sql
+++ b/extension/sql/vectorize--0.21.1--0.22.0.sql
@@ -1,0 +1,9 @@
+-- Rename 'table' key to 'relation' in the params JSONB column
+UPDATE vectorize.job
+SET params = jsonb_set(
+    params - 'table',  -- Remove old 'table' key
+    '{relation}', 
+    params->'table',  -- Copy value to new 'relation' key
+    true  -- Ensure key exists
+)
+WHERE params ? 'table';

--- a/extension/sql/vectorize--0.21.1--0.22.0.sql
+++ b/extension/sql/vectorize--0.21.1--0.22.0.sql
@@ -7,3 +7,25 @@ SET params = jsonb_set(
     true  -- Ensure key exists
 )
 WHERE params ? 'table';
+
+-- Update the function to reference "relation" instead of "table"
+CREATE OR REPLACE FUNCTION handle_table_drop()
+RETURNS event_trigger AS $$
+DECLARE
+    obj RECORD;
+    schema_name TEXT;
+    relation_name TEXT;
+BEGIN
+    FOR obj IN SELECT * FROM pg_event_trigger_dropped_objects() LOOP
+        IF obj.object_type = 'table' THEN
+            schema_name := split_part(obj.object_identity, '.', 1);  
+            relation_name := split_part(obj.object_identity, '.', 2);  
+            
+            -- Perform cleanup: delete the associated job from the vectorize.job table
+            DELETE FROM vectorize.job
+            WHERE params ->> 'relation' = relation_name
+            AND params ->> 'schema' = schema_name;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -93,7 +93,7 @@ fn chunk_table(
 #[allow(clippy::too_many_arguments)]
 #[pg_extern]
 fn table(
-    table: &str,
+    relation: &str,
     columns: Vec<String>,
     job_name: &str,
     primary_key: &str,
@@ -115,7 +115,7 @@ fn table(
     init_table(
         job_name,
         schema,
-        table,
+        relation,
         columns.clone(),
         primary_key,
         update_time_col,
@@ -341,7 +341,7 @@ fn import_embeddings(
              FROM {} src
              WHERE t0.{} = src.{}",
             job_params.schema,
-            job_params.table,
+            job_params.relation,
             job_name,
             src_embeddings_col,
             job_name,
@@ -353,7 +353,7 @@ fn import_embeddings(
         Spi::run(&update_q)?;
         let count_query = format!(
             "SELECT count(*) FROM {}.{}",
-            job_params.schema, job_params.table
+            job_params.schema, job_params.relation
         );
         Spi::get_one::<i64>(&count_query)?.unwrap_or(0) as i32
     };
@@ -379,7 +379,7 @@ fn import_embeddings(
 #[allow(clippy::too_many_arguments)]
 #[pg_extern]
 fn table_from(
-    table: &str,
+    relation: &str,
     columns: Vec<String>,
     job_name: &str,
     primary_key: &str,
@@ -405,7 +405,7 @@ fn table_from(
     init_table(
         job_name,
         schema,
-        table,
+        relation,
         columns.clone(),
         primary_key,
         update_time_col,
@@ -424,8 +424,8 @@ fn table_from(
         let trigger_handler = create_trigger_handler(job_name, &columns, primary_key);
         Spi::run(&trigger_handler)?;
 
-        let insert_trigger = create_event_trigger(job_name, schema, table, "INSERT");
-        let update_trigger = create_event_trigger(job_name, schema, table, "UPDATE");
+        let insert_trigger = create_event_trigger(job_name, schema, relation, "INSERT");
+        let update_trigger = create_event_trigger(job_name, schema, relation, "UPDATE");
 
         Spi::run(&insert_trigger)?;
         Spi::run(&update_trigger)?;

--- a/extension/src/executor.rs
+++ b/extension/src/executor.rs
@@ -129,7 +129,7 @@ pub fn new_rows_query_join(job_name: &str, job_params: &JobParams) -> String {
         .collect::<Vec<_>>()
         .join(",");
     let schema = job_params.schema.clone();
-    let table = job_params.table.clone();
+    let table = job_params.relation.clone();
 
     let base_query = format!(
         "
@@ -178,7 +178,7 @@ pub fn new_rows_query(job_name: &str, job_params: &JobParams) -> String {
         ",
         record_id = job_params.primary_key,
         schema = job_params.schema,
-        table = job_params.table,
+        table = job_params.relation,
     );
     if let Some(updated_at_col) = &job_params.update_time_col {
         // updated_at_column is not required when `schedule` is realtime

--- a/extension/src/init.rs
+++ b/extension/src/init.rs
@@ -82,7 +82,7 @@ fn create_project_view(job_name: &str, job_params: &JobParams) -> String {
         ",
         job_name = job_name,
         schema = job_params.schema,
-        table = job_params.table,
+        table = job_params.relation,
         primary_key = job_params.primary_key,
     )
 }
@@ -90,7 +90,7 @@ fn create_project_view(job_name: &str, job_params: &JobParams) -> String {
 pub fn init_index_query(job_name: &str, job_params: &JobParams) -> String {
     check_input(job_name).expect("invalid job name");
     let src_schema = job_params.schema.clone();
-    let src_table = job_params.table.clone();
+    let src_table = job_params.relation.clone();
 
     format!(
         "
@@ -111,7 +111,7 @@ pub fn init_embedding_table_query(
 ) -> Vec<String> {
     check_input(job_name).expect("invalid job name");
     let src_schema = job_params.schema.clone();
-    let src_table = job_params.table.clone();
+    let src_table = job_params.relation.clone();
 
     let col_type = format!("vector({model_dim})");
 

--- a/extension/src/search.rs
+++ b/extension/src/search.rs
@@ -116,7 +116,7 @@ pub fn init_table(
 
     let valid_params = types::JobParams {
         schema: schema.to_string(),
-        table: table.to_string(),
+        relation: table.to_string(),
         columns: columns.clone(),
         update_time_col: update_col,
         table_method: table_method.clone(),
@@ -222,7 +222,7 @@ pub fn full_text_search(
              @@ to_tsquery('english', '{query}')
              LIMIT {limit};",
         schema = proj_params.schema,
-        table = proj_params.table,
+        table = proj_params.relation,
         return_columns = return_columns.join(", "),
         search_columns = search_columns, // Dynamically concatenate columns
         query = query
@@ -426,7 +426,7 @@ pub fn cosine_similarity_search(
     where_clause: Option<String>,
 ) -> Result<Vec<JsonB>> {
     let schema = job_params.schema.clone();
-    let table = job_params.table.clone();
+    let table = job_params.relation.clone();
 
     // switch on table method
     let query = match job_params.table_method {
@@ -474,7 +474,7 @@ fn join_table_cosine_similarity(
     where_clause: Option<String>,
 ) -> String {
     let schema = job_params.schema.clone();
-    let table = job_params.table.clone();
+    let table = job_params.relation.clone();
     let join_key = &job_params.primary_key;
     let cols = &return_columns
         .iter()

--- a/extension/src/workers/mod.rs
+++ b/extension/src/workers/mod.rs
@@ -96,7 +96,7 @@ async fn execute_job(dbclient: Pool<Postgres>, msg: Message<types::JobMessage>) 
             ops::update_embeddings(
                 &dbclient,
                 &job_params.schema,
-                &job_params.table,
+                &job_params.relation,
                 &job_meta.clone().name,
                 &job_params.primary_key,
                 &job_params.pkey_type,

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -19,7 +19,7 @@ async fn test_scheduled_job() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -65,7 +65,7 @@ async fn test_hybrid_search() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -170,7 +170,7 @@ async fn test_scheduled_single_table() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -219,7 +219,7 @@ async fn test_realtime_append_fail() {
     let result = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -248,7 +248,7 @@ async fn test_realtime_job() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name', 'description'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -411,7 +411,7 @@ async fn test_static() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name', 'description'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -504,7 +504,7 @@ async fn test_realtime_tabled() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -579,7 +579,7 @@ async fn test_filter_join() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -638,7 +638,7 @@ async fn test_filter_append() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -678,7 +678,7 @@ async fn test_index_dist_type_hnsw_cosine() {
     let query = format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         index_dist_type => '{dist_type}',
@@ -735,7 +735,7 @@ async fn test_index_dist_type_hnsw_l2() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{job_name}',
-            \"table\" => '{test_table_name}',
+            relation => '{test_table_name}',
             primary_key => 'product_id',
             columns => ARRAY['product_name'],
             index_dist_type => '{dist_type}',
@@ -786,7 +786,7 @@ async fn test_index_dist_type_hnsw_ip() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{job_name}',
-            \"table\" => '{test_table_name}',
+            relation => '{test_table_name}',
             primary_key => 'product_id',
             columns => ARRAY['product_name'],
             index_dist_type => '{dist_type}',
@@ -848,7 +848,7 @@ async fn test_private_hf_model() {
     let created = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'chuckhend/private-model',
@@ -895,7 +895,7 @@ async fn test_diskann_cosine() {
     let result = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -944,7 +944,7 @@ async fn test_cohere() {
     let result = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'cohere/embed-multilingual-light-v3.0',
@@ -979,7 +979,7 @@ async fn test_event_trigger_on_table_drop() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
         job_name => '{job_name}',
-        \"table\" => '{test_table_name}',
+        relation => '{test_table_name}',
         primary_key => 'product_id',
         columns => ARRAY['product_name'],
         transformer => 'sentence-transformers/all-MiniLM-L6-v2'
@@ -1183,7 +1183,7 @@ async fn test_import_embeddings() {
     sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{}',
-            \"table\" => '{}',
+            relation => '{}',
             primary_key => 'id',
             columns => ARRAY['content'],
             transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -1261,7 +1261,7 @@ async fn test_import_embeddings() {
     sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{}',
-            \"table\" => '{}',
+            relation => '{}',
             primary_key => 'id',
             columns => ARRAY['content'],
             transformer => 'sentence-transformers/all-MiniLM-L6-v2',
@@ -1376,7 +1376,7 @@ async fn test_table_from() {
     let realtime_job_name = format!("table_from_test_realtime_{}", test_num);
     sqlx::query(&format!(
         "SELECT vectorize.table_from(
-            \"table\" => '{}',
+            relation => '{}',
             columns => ARRAY['content'],
             job_name => '{}',
             primary_key => 'id',
@@ -1396,7 +1396,7 @@ async fn test_table_from() {
     let cron_job_name = format!("table_from_test_cron_{}", test_num);
     sqlx::query(&format!(
         "SELECT vectorize.table_from(
-            \"table\" => '{}',
+            relation => '{}',
             columns => ARRAY['content'],
             job_name => '{}',
             primary_key => 'id',


### PR DESCRIPTION
I have closing #208 as there is issue in converting as using `REGCLASS` in the relation needs conversion to the native Oid in sqlx but on trying to conversion there is a consistency mismatch on the different types. So keeping the value as string and renamed. 

- Modified the tests
- Modified the docs. 

fixes #145 
/claim #145 