### PR TITLE
deprecate .init_rag() in favor of .table()

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,12 @@ Initialize the RAG project.
 
 ```sql
 SELECT vectorize.table(
-    job_name            => 'product_chat',
-    table_name          => 'products',
-    "column"            => 'context',
-    unique_record_id    => 'product_id',
-    transformer         => 'openai/text-embedding-3-small'
+    job_name    => 'product_chat',
+    "table"     => 'products',
+    primary_key => 'product_id',
+    columns     => ARRAY['context'],
+    transformer => 'openai/text-embedding-3-small',
+    schedule    => 'realtime'
 );
 ```
 
@@ -222,7 +223,7 @@ And to use a locally hosted Ollama service, change the `chat_model` parameter:
 
 ```sql
 SELECT vectorize.rag(
-    agent_name  => 'product_chat',
+    job_name    => 'product_chat',
     query       => 'What is a pencil?',
     chat_model  => 'ollama/wizardlm2:7b'
 ) -> 'chat_response';

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Initialize the RAG project.
  We'll use the `openai/text-embedding-3-small` model to generate embeddings on our source documents.
 
 ```sql
-SELECT vectorize.init_rag(
-    agent_name          => 'product_chat',
+SELECT vectorize.table(
+    job_name            => 'product_chat',
     table_name          => 'products',
     "column"            => 'context',
     unique_record_id    => 'product_id',
@@ -208,7 +208,7 @@ Now we can ask questions of the `products` table and get responses from the `pro
 
 ```sql
 SELECT vectorize.rag(
-    agent_name  => 'product_chat',
+    job_name    => 'product_chat',
     query       => 'What is a pencil?',
     chat_model  => 'openai/gpt-3.5-turbo'
 ) -> 'chat_response';
@@ -237,7 +237,7 @@ SELECT vectorize.rag(
 
 ## Updating Embeddings
 
-When the source text data is updated, how and when the embeddings are updated is determined by the value set to the `schedule` parameter in `vectorize.table` and `vectorize.init_rag`.
+When the source text data is updated, how and when the embeddings are updated is determined by the value set to the `schedule` parameter in `vectorize.table`.
 
 The default behavior is `schedule => '* * * * *'`, which means the background worker process checks for changes every minute, and updates the embeddings accordingly. This method requires setting the `updated_at_col` value to point to a colum on the table indicating the time that the input text columns were last changed. `schedule` can be set to any cron-like value.
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Initialize the RAG project.
 ```sql
 SELECT vectorize.table(
     job_name    => 'product_chat',
-    "table"     => 'products',
+    relation    => 'products',
     primary_key => 'product_id',
     columns     => ARRAY['context'],
     transformer => 'openai/text-embedding-3-small',

--- a/docs/api/rag.md
+++ b/docs/api/rag.md
@@ -6,11 +6,11 @@ SQL API for Retrieval Augmented Generation projects.
 
 Creates embeddings for specified data in a Postgres table. Creates index, and triggers to keep embeddings up to date.
 
-### `vectorize.init_rag`
+### `vectorize.table`
 
 ```sql
-vectorize.init_rag(
-    "agent_name" TEXT,
+vectorize.table(
+    "job_name" TEXT,
     "table_name" TEXT,
     "unique_record_id" TEXT,
     "column" TEXT,
@@ -37,8 +37,8 @@ vectorize.init_rag(
 Example:
 
 ```sql
-select vectorize.init_rag(
-    agent_name        => 'tembo_chat',
+select vectorize.table(
+    job_name          => 'tembo_chat',
     table_name        => 'tembo_docs',
     unique_record_id  => 'document_name',
     "column"          => 'content',
@@ -70,7 +70,7 @@ vectorize."rag"(
 
 | Parameter      | Type | Description     |
 | :---        |    :----   |          :--- |
-| agent_name | text | Specify the name provided during vectorize.init_rag |
+| job_name | text | Specify the name provided during vectorize.table |
 | query | text | The user provided query or command provided to the chat completion model.  |
 | task | text | Specifies the name of the prompt template to use. Must exist in vectorize.prompts (prompt_type) |
 | api_key | text | API key for the specified chat model. If OpenAI, this value overrides the config `vectorize.openai_key` |

--- a/docs/api/rag.md
+++ b/docs/api/rag.md
@@ -8,10 +8,9 @@ Creates embeddings for specified data in a Postgres table. Creates index, and tr
 
 ### `vectorize.table`
 
-
 ```sql
 vectorize."table"(
-    "table" TEXT,
+    "relation" TEXT,
     "columns" TEXT[],
     "job_name" TEXT,
     "primary_key" TEXT,
@@ -26,7 +25,7 @@ vectorize."table"(
 
 | Parameter      | Type | Description     |
 | :---        |    :----   |          :--- |
-| table | text | The name of the table to be initialized. |
+| relation | text | The name of the table to be initialized. |
 | columns | text | The name of the columns that contains the content that is used for context for RAG. Multiple columns are concatenated. |
 | job_name | text | A unique name for the project. |
 | primary_key | text | The name of the column that contains the unique record id. |

--- a/docs/examples/scheduling.md
+++ b/docs/examples/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling Embedding Updates
 
-When the source text data is updated, how and when the embeddings are updated is determined by the value set to the `schedule` parameter in `vectorize.table` and `vectorize.init_rag`.
+When the source text data is updated, how and when the embeddings are updated is determined by the value set to the `schedule` parameter in `vectorize.table`s.
 
 The default behavior is `schedule => '* * * * *'`, which means the background worker process checks for changes every minute, and updates the embeddings accordingly. This method requires setting the `updated_at_col` value to point to a colum on the table indicating the time that the input text columns were last changed. `schedule` can be set to any cron-like value.
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -195,7 +195,7 @@ The text-generation models are available as part of the [RAG](../api/rag.md) API
 
 ```sql
 SELECT vectorize.rag(
-    agent_name  => 'product_chat',
+    job_name    => 'product_chat',
     query       => 'What is a pencil?',
     chat_model  => 'ollama/wizardlm2:7b'
 );
@@ -218,7 +218,7 @@ Then use that model in your RAG application:
 
 ```sql
 SELECT vectorize.rag(
-    agent_name  => 'product_chat',
+    job_name    => 'product_chat',
     query       => 'What is a pencil?'
     chat_model  => 'ollama/llama3'
 );

--- a/extension/sql/vectorize--0.21.1--0.22.0.sql
+++ b/extension/sql/vectorize--0.21.1--0.22.0.sql
@@ -1,0 +1,17 @@
+
+DROP FUNCTION IF EXISTS vectorize."rag";
+
+CREATE  FUNCTION vectorize."rag"(
+	"job_name" TEXT, /* &str */
+	"query" TEXT, /* &str */
+	"chat_model" TEXT DEFAULT 'openai/gpt-4o-mini', /* alloc::string::String */
+	"task" TEXT DEFAULT 'question_answer', /* alloc::string::String */
+	"api_key" TEXT DEFAULT NULL, /* core::option::Option<alloc::string::String> */
+	"num_context" INT DEFAULT 2, /* i32 */
+	"force_trim" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"chat_results" jsonb  /* pgrx::datum::json::JsonB */
+)
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'rag_wrapper';
+

--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -228,7 +228,7 @@ fn init_rag(
 fn rag(
     job_name: &str,
     query: &str,
-    chat_model: default!(String, "'tembo/meta-llama/Meta-Llama-3-8B-Instruct'"),
+    chat_model: default!(String, "'openai/gpt-4o-mini'"),
     // points to the type of prompt template to use
     task: default!(String, "'question_answer'"),
     api_key: default!(Option<String>, "NULL"),

--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -190,6 +190,7 @@ fn encode(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[deprecated(since = "0.22.0", note = "Please use vectorize.table() instead")]
 #[pg_extern]
 fn init_rag(
     agent_name: &str,
@@ -204,6 +205,7 @@ fn init_rag(
     table_method: default!(types::TableMethod, "'join'"),
     schedule: default!(&str, "'* * * * *'"),
 ) -> Result<String> {
+    pgrx::warning!("DEPRECATED: vectorize.init_rag() will be removed in a future version. Please use vectorize.table() instead.");
     // chat only supports single columns transform
     let columns = vec![column.to_string()];
     let transformer_model = Model::new(transformer)?;
@@ -224,7 +226,7 @@ fn init_rag(
 /// creates a table indexed with embeddings for chat completion workloads
 #[pg_extern]
 fn rag(
-    agent_name: &str,
+    job_name: &str,
     query: &str,
     chat_model: default!(String, "'tembo/meta-llama/Meta-Llama-3-8B-Instruct'"),
     // points to the type of prompt template to use
@@ -237,7 +239,7 @@ fn rag(
 ) -> Result<TableIterator<'static, (name!(chat_results, pgrx::JsonB),)>> {
     let model = Model::new(&chat_model)?;
     let resp = call_chat(
-        agent_name,
+        job_name,
         query,
         &model,
         &task,

--- a/extension/src/chat/ops.rs
+++ b/extension/src/chat/ops.rs
@@ -17,7 +17,7 @@ use tiktoken_rs::{get_bpe_from_model, model::get_context_size, CoreBPE};
 use vectorize_core::types::{JobParams, VectorizeMeta};
 
 pub fn call_chat(
-    agent_name: &str,
+    job_name: &str,
     query: &str,
     chat_model: &Model,
     task: &str,
@@ -26,7 +26,7 @@ pub fn call_chat(
     force_trim: bool,
 ) -> Result<ChatResponse> {
     // get job metadata
-    let project_meta: VectorizeMeta = get_vectorize_meta_spi(agent_name)?;
+    let project_meta: VectorizeMeta = get_vectorize_meta_spi(job_name)?;
 
     let job_params = serde_json::from_value::<JobParams>(project_meta.params.clone())
         .unwrap_or_else(|e| error!("failed to deserialize job params: {}", e));
@@ -60,14 +60,7 @@ pub fn call_chat(
     let pk = job_params.primary_key;
     let columns = vec![pk.clone(), content_column.clone()];
 
-    let raw_search = search::search(
-        agent_name,
-        query,
-        api_key.clone(),
-        columns,
-        num_context,
-        None,
-    )?;
+    let raw_search = search::search(job_name, query, api_key.clone(), columns, num_context, None)?;
 
     let mut search_results: Vec<ContextualSearch> = Vec::new();
     for s in raw_search {

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -344,9 +344,9 @@ async fn test_rag() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{agent_name}',
-            table_name => '{test_table_name}',
-            unique_record_id => 'product_id',
-            \"column\" => 'description',
+            \"table\" => '{test_table_name}',
+            primary_key => 'product_id',
+            columns => ARRAY['description'],
             transformer => 'sentence-transformers/all-MiniLM-L6-v2'
     );"
     ))
@@ -377,9 +377,9 @@ async fn test_rag_alternate_schema() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{agent_name}',
-            table_name => '{test_table_name}',
-            unique_record_id => 'product_id',
-            \"column\" => 'description',
+            \"table\" => '{test_table_name}',
+            primary_key => 'product_id',
+            columns => ARRAY['description'],
             transformer => 'sentence-transformers/all-MiniLM-L6-v2'
     );"
     ))

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -342,8 +342,8 @@ async fn test_rag() {
 
     // initialize
     let _ = sqlx::query(&format!(
-        "SELECT vectorize.init_rag(
-            agent_name => '{agent_name}',
+        "SELECT vectorize.table(
+            job_name => '{agent_name}',
             table_name => '{test_table_name}',
             unique_record_id => 'product_id',
             \"column\" => 'description',
@@ -375,8 +375,8 @@ async fn test_rag_alternate_schema() {
 
     // initialize
     let _ = sqlx::query(&format!(
-        "SELECT vectorize.init_rag(
-            agent_name => '{agent_name}',
+        "SELECT vectorize.table(
+            job_name => '{agent_name}',
             table_name => '{test_table_name}',
             unique_record_id => 'product_id',
             \"column\" => 'description',

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -336,7 +336,7 @@ async fn test_rag() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{agent_name}',
-            \"table\" => '{test_table_name}',
+            relation => '{test_table_name}',
             primary_key => 'product_id',
             columns => ARRAY['description'],
             transformer => 'sentence-transformers/all-MiniLM-L6-v2'
@@ -368,7 +368,7 @@ async fn test_rag_alternate_schema() {
     let _ = sqlx::query(&format!(
         "SELECT vectorize.table(
             job_name => '{agent_name}',
-            \"table\" => '{test_table_name}',
+            relation => '{test_table_name}',
             primary_key => 'product_id',
             columns => ARRAY['description'],
             transformer => 'sentence-transformers/all-MiniLM-L6-v2'


### PR DESCRIPTION
Deprecate vectorize.init_rag(). Just use vectorize.table() to keep API more consistent and simple.

Also changes `vectorize.rag()` signature: `agent_name` is now `job_name` so that it is consistent with the rest of the project's APIs. 

closes #188 