### PR TITLE
only run integration tests from main repository

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -111,7 +111,7 @@ jobs:
           PORTKEY_VIRTUAL_KEY_OPENAI: ${{ secrets.PORTKEY_VIRTUAL_KEY_OPENAI }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
         run: |
-          cd ../core && cargo test --ignored
+          cd ../core && cargo test -- --ignored
 
   test:
     name: Run tests
@@ -155,6 +155,7 @@ jobs:
           make setup
       - name: unit-test
         run: |
+          echo "\q" | make run
           make test-unit
       - name: integration-test
         if: github.repository == 'tembo-io/pg_vectorize'
@@ -164,9 +165,7 @@ jobs:
           PORTKEY_API_KEY: ${{ secrets.PORTKEY_API_KEY }}
           PORTKEY_VIRTUAL_KEY_OPENAI: ${{ secrets.PORTKEY_VIRTUAL_KEY_OPENAI }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
-        run: |
-          echo "\q" | make run
-          make test-integration
+        run: make test-integration
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Test Core - Integration
         # skip when on external forks
-        if: github.repository == 'tembo-io/pgmq'
+        if: github.repository == 'tembo-io/pg_vectorize'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -157,6 +157,7 @@ jobs:
         run: |
           make test-unit
       - name: integration-test
+        if: github.repository == 'tembo-io/pg_vectorize'
         env:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -98,6 +98,12 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib libopenblas-dev libreadline-dev
       - name: Test Core
+        run: |
+          cd ../core && cargo test
+
+      - name: Test Core - Integration
+        # skip when on external forks
+        if: github.repository == 'tembo-io/pgmq'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
@@ -105,7 +111,7 @@ jobs:
           PORTKEY_VIRTUAL_KEY_OPENAI: ${{ secrets.PORTKEY_VIRTUAL_KEY_OPENAI }}
           VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
         run: |
-          cd ../core && cargo test
+          cd ../core && cargo test --ignored
 
   test:
     name: Run tests

--- a/core/src/transformers/providers/cohere.rs
+++ b/core/src/transformers/providers/cohere.rs
@@ -113,6 +113,7 @@ mod integration_tests {
     use super::*;
     use tokio::test as async_test;
 
+    #[ignore]
     #[async_test]
     async fn test_generate_embedding() {
         let provider = CohereProvider::new(Some(COHERE_BASE_URL.to_string()), None);

--- a/core/src/transformers/providers/openai.rs
+++ b/core/src/transformers/providers/openai.rs
@@ -183,6 +183,7 @@ mod integration_tests {
     use super::*;
     use tokio::test as async_test;
 
+    #[ignore]
     #[async_test]
     async fn test_generate_embedding() {
         let provider = OpenAIProvider::new(Some(OPENAI_BASE_URL.to_string()), None);

--- a/core/src/transformers/providers/portkey.rs
+++ b/core/src/transformers/providers/portkey.rs
@@ -132,6 +132,7 @@ mod portkey_integration_tests {
     use super::*;
     use tokio::test as async_test;
 
+    #[ignore]
     #[async_test]
     async fn test_portkey_openai() {
         let portkey_api_key = env::var("PORTKEY_API_KEY").expect("PORTKEY_API_KEY not set");

--- a/core/src/transformers/providers/voyage.rs
+++ b/core/src/transformers/providers/voyage.rs
@@ -113,6 +113,7 @@ mod integration_tests {
     use super::*;
     use std::env;
 
+    #[ignore]
     #[tokio::test]
     async fn test_voyage_ai_embedding() {
         let api_key = Some(env::var("VOYAGE_API_KEY").expect("VOYAGE_API_KEY must be set"));

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -94,7 +94,7 @@ test-integration:
 	cargo test ${TEST_NAME} -- --ignored --test-threads=1 --nocapture
 
 test-unit:
-	cargo pgrx test -- --test-threads=1
+	cargo test -- --test-threads=1
 
 test-version:
 	git fetch --tags

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -94,7 +94,7 @@ test-integration:
 	cargo test ${TEST_NAME} -- --ignored --test-threads=1 --nocapture
 
 test-unit:
-	cargo pgrx test
+	cargo pgrx test -- --test-threads=1
 
 test-version:
 	git fetch --tags

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -2,8 +2,6 @@ mod util;
 use rand::Rng;
 use util::common;
 
-// Integration tests are ignored by default
-#[ignore]
 #[tokio::test]
 async fn test_scheduled_job() {
     let conn = common::init_database().await;
@@ -52,7 +50,6 @@ async fn test_scheduled_job() {
     assert_eq!(result.rows_affected(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_hybrid_search() {
     let conn = common::init_database().await;
@@ -86,7 +83,6 @@ async fn test_hybrid_search() {
     assert_eq!(hybrid_search_results.len(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_chunk_text() {
     let conn = common::init_database().await;
@@ -154,7 +150,6 @@ async fn test_chunk_text() {
     );
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_scheduled_single_table() {
     let conn = common::init_database().await;
@@ -204,7 +199,6 @@ async fn test_scheduled_single_table() {
     assert_eq!(result.rows_affected(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_realtime_append_fail() {
     let conn = common::init_database().await;
@@ -233,7 +227,6 @@ async fn test_realtime_append_fail() {
     assert!(result.is_err());
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_realtime_job() {
     let conn = common::init_database().await;
@@ -329,7 +322,6 @@ async fn test_realtime_job() {
     assert!(found_it);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_rag() {
     let conn = common::init_database().await;
@@ -362,7 +354,6 @@ async fn test_rag() {
     assert_eq!(search_results.len(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_rag_alternate_schema() {
     let conn = common::init_database().await;
@@ -395,7 +386,6 @@ async fn test_rag_alternate_schema() {
     assert_eq!(search_results.len(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_static() {
     // a static test. intended for use across extension version updates
@@ -489,7 +479,6 @@ async fn test_static() {
     assert!(found_it, "resulting records: {:?}", search_results);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_realtime_tabled() {
     let conn = common::init_database().await;
@@ -564,7 +553,6 @@ async fn test_realtime_tabled() {
     assert!(result.len() == 41);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_filter_join() {
     let conn = common::init_database().await;
@@ -623,7 +611,6 @@ async fn test_filter_join() {
     assert_eq!(product_id_val, 1);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_filter_append() {
     let conn = common::init_database().await;
@@ -662,7 +649,6 @@ async fn test_filter_append() {
     assert_eq!(product_id_val, 2);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_index_dist_type_hnsw_cosine() {
     let conn = common::init_database().await;
@@ -719,8 +705,6 @@ async fn test_index_dist_type_hnsw_cosine() {
     );
 }
 
-#[tokio::test]
-#[ignore]
 async fn test_index_dist_type_hnsw_l2() {
     let conn = common::init_database().await;
     common::init_embedding_svc_url(&conn).await;
@@ -771,7 +755,6 @@ async fn test_index_dist_type_hnsw_l2() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_index_dist_type_hnsw_ip() {
     let conn = common::init_database().await;
     common::init_embedding_svc_url(&conn).await;
@@ -880,7 +863,6 @@ async fn test_private_hf_model() {
     assert_eq!(result.rows_affected(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_diskann_cosine() {
     let conn = common::init_database().await;
@@ -963,7 +945,6 @@ async fn test_cohere() {
     assert_eq!(search_results.len(), 3);
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_event_trigger_on_table_drop() {
     let conn = common::init_database().await;
@@ -1037,7 +1018,6 @@ async fn test_event_trigger_on_table_drop() {
     );
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_chunk_table() {
     let conn = common::init_database().await;
@@ -1108,7 +1088,6 @@ async fn test_chunk_table() {
     assert_eq!(rows[7].2, "pieces.");
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_import_embeddings() {
     let conn = common::init_database().await;
@@ -1301,7 +1280,6 @@ async fn test_import_embeddings() {
     );
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_table_from() {
     let conn = common::init_database().await;


### PR DESCRIPTION
Any tests that require API keys or secrets will fail on PRs from external branches. So just limit those tests to run on PRs from the main repository only by marking them all as `#[ignore]` or feature flag, then running those tests in a separate step.

addresses #187 