### PR TITLE
prep v0.22

### DIFF
--- a/.github/actions/pgx-init/action.yml
+++ b/.github/actions/pgx-init/action.yml
@@ -27,7 +27,7 @@ runs:
             echo "pgrx is not a dependency: skipping"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
-            cargo install --version ${pgrx_version} cargo-pgrx
+            cargo install --version ${pgrx_version} cargo-pgrx --locked
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
       - name: pgrx init

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -86,10 +86,6 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-    # runs-on:
-    #   - self-hosted
-    #   - dind
-    #   - large-8x8
     services:
       # Label used to access the service container
       vector-serve:

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+      - v0.22.0
     paths-ignore:
       - "README.md"
       - docs/**
@@ -23,36 +24,6 @@ on:
     types:
       - created
 jobs:
-  dependencies:
-    name: Install dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # rust needed to install trunk
-      - name: Install Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install stoml and pg-trunk
-        shell: bash
-        run: |
-          set -xe
-          wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
-          mv stoml_linux_amd64 stoml
-          chmod +x stoml
-          sudo mv stoml /usr/local/bin/
-          cargo install pg-trunk
-
-      - name: Cache binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/local/bin/stoml
-            ~/.cargo/bin/trunk
-          key: ${{ runner.os }}-bins-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-bins-
-
   lint:
     name: Run linters
     runs-on: ubuntu-latest
@@ -103,7 +74,7 @@ jobs:
 
       - name: Test Core - Integration
         # skip when on external forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.repository_owner == 'tembo-io'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
@@ -115,8 +86,11 @@ jobs:
 
   test:
     name: Run tests
-    needs: dependencies
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    # runs-on:
+    #   - self-hosted
+    #   - dind
+    #   - large-8x8
     services:
       # Label used to access the service container
       vector-serve:
@@ -129,7 +103,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "extension-test"
           workspaces: |
             vectorize
           # Additional directories to cache
@@ -137,19 +110,10 @@ jobs:
             /home/runner/.pgrx
       - name: Install sys dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y postgresql-server-dev-16 libopenblas-dev libreadline-dev
+          sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev zlib1g-dev flex bison libclang-dev postgresql-client libicu-dev make wget pkg-config libssl-dev git gcc libopenblas-dev
       - uses: ./.github/actions/pgx-init
         with:
           working-directory: ./extension
-      - name: Restore cached binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/local/bin/stoml
-            ~/.cargo/bin/trunk
-          key: ${{ runner.os }}-bins-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-bins-
       - name: setup-tests
         run: |
           make setup
@@ -158,7 +122,7 @@ jobs:
           echo "\q" | make run
           make test-unit
       - name: integration-test
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.repository_owner == 'tembo-io'
         env:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - main
-      - v0.22.0
     paths-ignore:
       - "README.md"
       - docs/**

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -60,6 +60,8 @@ jobs:
           trunk install vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
           git fetch --tags
           git checkout tags/v0.20.0
+          # pgrx=0.12.5 required for v0.20.0
+          cargo install cargo-pgrx --version 0.12.5 --locked
           make test-integration
       - name: Test branch's version
         env:

--- a/.github/workflows/pg-image-build.yml
+++ b/.github/workflows/pg-image-build.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "TAG_VER=$(/usr/local/bin/stoml extension/Cargo.toml package.version)" >> $GITHUB_OUTPUT
+          echo "PGRX_VER=$(/usr/local/bin/stoml extension/Cargo.toml dependencies.pgrx | tr -d '="')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,6 +67,7 @@ jobs:
         if: github.event_name != 'release'
         run: |
             docker build \
+                --build-arg PGRX_VER=${{ steps.versions.outputs.PGRX_VER }} \
                 -f ./images/vectorize-pg/Dockerfile \
                 -t quay.io/tembo/vectorize-pg:${{ steps.versions.outputs.SHORT_SHA }}-amd64 .
             docker push quay.io/tembo/vectorize-pg:${{ steps.versions.outputs.SHORT_SHA }}-amd64
@@ -74,6 +76,7 @@ jobs:
         if: github.event_name == 'release'
         run: |
             docker build \
+                --build-arg PGRX_VER=${{ steps.versions.outputs.PGRX_VER }} \
                 -f ./images/vectorize-pg/Dockerfile \
                 -t quay.io/tembo/vectorize-pg:v${{ steps.versions.outputs.TAG_VER }}-amd64 \
                 -t quay.io/tembo/vectorize-pg:latest-amd64 .
@@ -109,6 +112,7 @@ jobs:
         run: |
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "TAG_VER=$(/usr/local/bin/stoml extension/Cargo.toml package.version)" >> $GITHUB_OUTPUT
+          echo "PGRX_VER=$(/usr/local/bin/stoml extension/Cargo.toml dependencies.pgrx | tr -d '="')" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -125,6 +129,7 @@ jobs:
         if: github.event_name != 'release'
         run: |
             docker build \
+                --build-arg PGRX_VER=${{ steps.versions.outputs.PGRX_VER }} \
                 -f ./images/vectorize-pg/Dockerfile \
                 --platform linux/arm64 \
                 -t quay.io/tembo/vectorize-pg:${{ steps.versions.outputs.SHORT_SHA }}-arm64 .
@@ -134,6 +139,7 @@ jobs:
         if: github.event_name == 'release'
         run: |
             docker build \
+                --build-arg PGRX_VER=${{ steps.versions.outputs.PGRX_VER }} \
                 -f ./images/vectorize-pg/Dockerfile \
                 --platform linux/arm64 \
                 -t quay.io/tembo/vectorize-pg:v${{ steps.versions.outputs.TAG_VER }}-arm64 \

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorize"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 publish = false
 
@@ -25,7 +25,7 @@ chrono = {version = "0.4.26", features = ["serde"] }
 handlebars = "5.1.0"
 log = "0.4.21"
 pgmq = "0.29"
-pgrx = "=0.12.5"
+pgrx = "=0.13.1"
 reqwest = {version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0.103"
@@ -42,7 +42,7 @@ url = "2.4.0"
 vectorize_core = { path = "../core", package = "vectorize-core" }
 
 [dev-dependencies]
-pgrx-tests = "=0.12.5"
+pgrx-tests = "=0.13.1"
 rand = "0.8.5"
 whoami = "1.4.1"
 

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -107,6 +107,7 @@ test-version:
 	cargo test -- --ignored --test-threads=1
 
 test-update:
+        cargo install cargo-pgrx --locked --version ${PGRX_VERSION}
 	echo "\q" | make run
 	psql ${DATABASE_URL} -c "CREATE EXTENSION IF NOT EXISTS vectorscale"
 	psql ${DATABASE_URL} -c "ALTER EXTENSION vectorize UPDATE"

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -107,7 +107,7 @@ test-version:
 	cargo test -- --ignored --test-threads=1
 
 test-update:
-        cargo install cargo-pgrx --locked --version ${PGRX_VERSION}
+	cargo install cargo-pgrx --locked --version ${PGRX_VERSION}
 	echo "\q" | make run
 	psql ${DATABASE_URL} -c "CREATE EXTENSION IF NOT EXISTS vectorscale"
 	psql ${DATABASE_URL} -c "ALTER EXTENSION vectorize UPDATE"

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -4,6 +4,7 @@ DISTVERSION  = $(shell grep -m 1 '^version' Trunk.toml | sed -e 's/[^"]*"\([^"]*
 PG_VERSION:=17
 DATABASE_URL:=postgres://${USER}:${USER}@localhost:288${PG_VERSION}/postgres
 PGRX_PG_CONFIG:=$(shell cargo pgrx info pg-config pg${PG_VERSION})
+PGRX_VERSION := $(shell grep -E "^pgrx\s*=" Cargo.toml | cut -d'"' -f2 | tr -d '=')
 UPGRADE_FROM_VER:=0.16.0
 BRANCH:=$(git rev-parse --abbrev-ref HEAD)
 RUST_LOG:=debug
@@ -86,15 +87,17 @@ install-vectorscale:
 	fi; \
 	git clone https://github.com/timescale/pgvectorscale.git && \
 	cd pgvectorscale/pgvectorscale && \
+	cargo install cargo-pgrx --locked --version $$(grep -E "^pgrx\s*=" Cargo.toml | cut -d'"' -f2 | tr -d '=') && \
 	cargo pgrx install --pg-config=${PGRX_PG_CONFIG} && \
 	cd ../.. && rm -rf pgvectorscale
+	cargo install cargo-pgrx --locked --version ${PGRX_VERSION}
 
 test-integration:
 	echo "\q" | make run
 	cargo test ${TEST_NAME} -- --ignored --test-threads=1 --nocapture
 
 test-unit:
-	cargo test -- --test-threads=1
+	cargo test ${TEST_NAME} -- --test-threads=1
 
 test-version:
 	git fetch --tags

--- a/extension/Trunk.toml
+++ b/extension/Trunk.toml
@@ -6,7 +6,7 @@ description = "The simplest way to orchestrate vector search on Postgres."
 homepage = "https://github.com/tembo-io/pg_vectorize"
 documentation = "https://github.com/tembo-io/pg_vectorize"
 categories = ["orchestration", "machine_learning"]
-version = "0.21.1"
+version = "0.22.0"
 loadable_libraries = [{ library_name = "vectorize", requires_restart = true }]
 
 [build]

--- a/extension/sql/vectorize--0.21.1--0.22.0.sql
+++ b/extension/sql/vectorize--0.21.1--0.22.0.sql
@@ -34,7 +34,7 @@ LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'table_wrapper';
 /* </end connected objects> */
 
-DROP FUNCTION vectorize."table_from";
+DROP FUNCTION IF EXISTS vectorize."table_from";
 -- src/api.rs:380
 -- vectorize::api::table_from
 CREATE  FUNCTION vectorize."table_from"(

--- a/extension/sql/vectorize--0.21.1--0.22.0.sql
+++ b/extension/sql/vectorize--0.21.1--0.22.0.sql
@@ -67,8 +67,7 @@ SET params = jsonb_set(
 WHERE params ? 'table';
 
 -- Update the function to reference "relation" instead of "table"
-DROP FUNCTION vectorize."handle_table_drop";
-CREATE FUNCTION vectorize.handle_table_drop()
+CREATE OR REPLACE FUNCTION vectorize.handle_table_drop()
 RETURNS event_trigger AS $$
 DECLARE
     obj RECORD;

--- a/extension/src/api.rs
+++ b/extension/src/api.rs
@@ -67,20 +67,7 @@ fn chunk_table(
         );
         Spi::run_with_args(
             &insert_query,
-            Some(vec![
-                (
-                    pgrx::PgOid::Custom(pgrx::pg_sys::INT4OID),
-                    original_id.into_datum(),
-                ), // OID for integer
-                (
-                    pgrx::PgOid::Custom(pgrx::pg_sys::INT4OID),
-                    chunk_index.into_datum(),
-                ), // OID for integer
-                (
-                    pgrx::PgOid::Custom(pgrx::pg_sys::TEXTOID),
-                    chunk.into_datum(),
-                ), // OID for text
-            ]),
+            &[original_id.into(), chunk_index.into(), chunk.into()],
         )?;
     }
 
@@ -271,11 +258,8 @@ fn generate(
 
 #[pg_extern]
 fn env_interpolate_guc(guc_name: &str) -> Result<String> {
-    let g: String = Spi::get_one_with_args(
-        "SELECT current_setting($1)",
-        vec![(PgBuiltInOids::TEXTOID.oid(), guc_name.into_datum())],
-    )?
-    .unwrap_or_else(|| panic!("no value set for guc: {guc_name}"));
+    let g: String = Spi::get_one_with_args("SELECT current_setting($1)", &[guc_name.into()])?
+        .unwrap_or_else(|| panic!("no value set for guc: {guc_name}"));
     env_interpolate_string(&g)
 }
 
@@ -366,10 +350,7 @@ fn import_embeddings(
             "DELETE FROM pgmq.q_{} WHERE message->>'job_name' = $1",
             VECTORIZE_QUEUE
         );
-        Spi::run_with_args(
-            &delete_q,
-            Some(vec![(PgBuiltInOids::TEXTOID.oid(), job_name.into_datum())]),
-        )?;
+        Spi::run_with_args(&delete_q, &[job_name.into()])?;
     }
 
     Ok(format!(

--- a/extension/src/bin/pgrx_embed.rs
+++ b/extension/src/bin/pgrx_embed.rs
@@ -1,2 +1,3 @@
 // https://github.com/pgcentralfoundation/pgrx/issues/1888
+#![allow(unexpected_cfgs)]
 ::pgrx::pgrx_embed!();

--- a/extension/src/chat/ops.rs
+++ b/extension/src/chat/ops.rs
@@ -85,7 +85,7 @@ pub fn call_chat(
     // read prompt template
     let res_prompts: Result<PromptTemplate, spi::Error> = Spi::connect(|c| {
         let q = format!("select * from vectorize.prompts where prompt_type = '{task}'");
-        let tup_table = c.select(&q, None, None)?;
+        let tup_table = c.select(&q, None, &[])?;
         let mut sys_prompt = String::new();
         let mut user_prompt = String::new();
         for row in tup_table {

--- a/extension/src/util.rs
+++ b/extension/src/util.rs
@@ -73,11 +73,7 @@ pub fn get_vectorize_meta_spi(job_name: &str) -> Result<types::VectorizeMeta> {
         WHERE name = $1
     ";
     let result: Result<types::VectorizeMeta> = Spi::connect(|client| {
-        let tup_table: SpiTupleTable = client.select(
-            query,
-            Some(1),
-            Some(vec![(PgBuiltInOids::TEXTOID.oid(), job_name.into_datum())]),
-        )?;
+        let tup_table: SpiTupleTable = client.select(query, Some(1), &[job_name.into()])?;
         if tup_table.is_empty() {
             return Err(anyhow::anyhow!(
                 "project '{}' not yet initialized. Please initialize the project.",

--- a/extension/tests/integration_tests.rs
+++ b/extension/tests/integration_tests.rs
@@ -887,7 +887,7 @@ async fn test_diskann_cosine() {
     ))
     .execute(&conn)
     .await;
-    assert!(result.is_ok());
+    assert!(result.is_ok(), "{:?}", result.err());
 
     let search_results: Vec<common::SearchJSON> =
         match util::common::search_with_retry(&conn, "mobile devices", &job_name, 10, 2, 3, None)

--- a/extension/tests/util.rs
+++ b/extension/tests/util.rs
@@ -53,7 +53,6 @@ pub mod common {
             .await
             .expect("failed to create extension");
 
-        // Optional dependencies
         let _ = sqlx::query("CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE")
             .execute(&conn)
             .await

--- a/images/vectorize-pg/Dockerfile
+++ b/images/vectorize-pg/Dockerfile
@@ -21,9 +21,9 @@ WORKDIR /vectorize
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN $HOME/.cargo/bin/rustup default stable
 
-# install pgrx
-ARG PGRX_VER=0.12.5
-RUN $HOME/.cargo/bin/cargo install cargo-pgrx --version=$PGRX_VER --locked
+# install pgrx and dependencies
+# compiling vectorscale requires pgrx 0.12.9
+RUN $HOME/.cargo/bin/cargo install cargo-pgrx --version=0.12.9 --locked
 RUN $HOME/.cargo/bin/cargo pgrx init --pg$PG_MAJ $(which pg_config)
 
 # set pgrx to use the correct pg_config
@@ -39,6 +39,10 @@ RUN export PATH="${HOME}/.cargo/bin:$PATH" && \
 	make setup.dependencies PGRX_PG_CONFIG=$(cargo pgrx info pg-config pg${PG_MAJ})
 
 # install pg-vectorize
+ARG PGRX_VER
+RUN $HOME/.cargo/bin/cargo install cargo-pgrx --version=$PGRX_VER --locked
+RUN $HOME/.cargo/bin/cargo pgrx init --pg$PG_MAJ $(which pg_config)
+
 RUN cd extension && \
 	$HOME/.cargo/bin/cargo pgrx install --pg-config=$(which pg_config)
 


### PR DESCRIPTION
1. upgrade pgrx to 0.13.1
2. fix the upgrade path to 0.22.0
3. make fts indexes optional when calling vectorize.table
4. bug/nit fixes in CI