### PR TITLE
install old w/ trunk in upgrade test

### DIFF
--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -50,15 +50,16 @@ jobs:
       - name: Install project dependencies
         run: |
           make setup
-      - name: Test previous version (main))
+          cargo install pg-trunk
+      - name: Test previous version (v0.20.0)
         env:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
         run: |
+          trunk install pg_vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
           git fetch --tags
-          git checkout main
-          echo "\q" | make run
+          git checkout tags/v0.20.0
           cargo test -- --ignored --test-threads=1
       - name: Test branch's version
         env:

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -51,16 +51,16 @@ jobs:
         run: |
           make setup
           cargo install pg-trunk
-      - name: Test previous version (v0.20.0)
+      - name: Test previous version (v0.18.0)
         env:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
         run: |
-          trunk install vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
+          trunk install vectorize --version 0.18.0 --pg-config $(cargo pgrx info pg-config pg17)
           git fetch --tags
           git checkout tags/v0.20.0
-          cargo test -- --ignored --test-threads=1
+          make test-integration
       - name: Test branch's version
         env:
           CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -57,7 +57,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
         run: |
-          trunk install pg_vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
+          trunk install vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
           git fetch --tags
           git checkout tags/v0.20.0
           cargo test -- --ignored --test-threads=1

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -51,13 +51,13 @@ jobs:
         run: |
           make setup
           cargo install pg-trunk
-      - name: Test previous version (v0.18.0)
+      - name: Test previous version (v0.20.0)
         env:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
         run: |
-          trunk install vectorize --version 0.18.0 --pg-config $(cargo pgrx info pg-config pg17)
+          trunk install vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
           git fetch --tags
           git checkout tags/v0.20.0
           make test-integration


### PR DESCRIPTION
Trying to get around issue compiling pgrx extensions, e.g. when vectorize uses pgrx 0.13.1 and a dependency uses a different version