### PR TITLE
check owner instead of event

### DIFF
--- a/.github/workflows/pg-image-build.yml
+++ b/.github/workflows/pg-image-build.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build_and_push_amd64:
     name: Build and push AMD64 images
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository_owner == 'tembo-io'
     runs-on:
       - self-hosted
       - dind
@@ -85,7 +85,7 @@ jobs:
 
   build_and_push_arm64:
     name: Build and push ARM64 images
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository_owner == 'tembo-io'
     runs-on:
       - arm64-4x16
     outputs:


### PR DESCRIPTION
We still want these jobs to run when not a PR event, but only when run from the tembo-io repository since secrets are required.